### PR TITLE
Don't run CI pipeline on pull requests that change documentation only

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1,10 +1,9 @@
 name: CI Pipeline
 
-# The CI pipeline runs under the following criteria.
-#   - On every push that modifies Cabal configuration, source or example files.
-#     If just the README or documentation changes, the pipeline does not have
-#     to run. It also runs when the Workflow configuration changed itself.
-#   - On every pull request regardless of which files have been changed.
+# The CI pipeline runs on every push and pull request that modifies Cabal
+# configuration, source or example files. If just the README or documentation
+# changes, the pipeline does not have to run. It also runs when the Workflow
+# configuration changed itself.
 on:
   push:
     paths:
@@ -14,7 +13,14 @@ on:
     - 'example/**'
     - 'src/**'
     - '.github/workflows/ci-pipeline.yml'
-  pull_request: {}
+  pull_request:
+    paths:
+    - 'cabal.project'
+    - 'free-compiler.cabal'
+    - 'base/**'
+    - 'example/**'
+    - 'src/**'
+    - '.github/workflows/ci-pipeline.yml'
 
 jobs:
   #############################################################################

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1,18 +1,11 @@
 name: CI Pipeline
 
-# The CI pipeline runs on every push and pull request that modifies Cabal
-# configuration, source or example files. If just the README or documentation
-# changes, the pipeline does not have to run. It also runs when the Workflow
-# configuration changed itself.
+# The CI pipeline runs whenever a pull request that modifies the compiler's
+# build configuration, source or example files is opened, synchronized (i.e.,
+# updated due to a new push to the branch that is tracked by the pull request)
+# or reopened. If just the README or documentation changes, the pipeline does
+# not have to run. It also runs when the Workflow configuration changed itself.
 on:
-  push:
-    paths:
-    - 'cabal.project'
-    - 'free-compiler.cabal'
-    - 'base/**'
-    - 'example/**'
-    - 'src/**'
-    - '.github/workflows/ci-pipeline.yml'
   pull_request:
     paths:
     - 'cabal.project'


### PR DESCRIPTION
Since the master branch is now protected, updates of the README and documentation have to be performed via pull requests, too. In order to avoid wasting resources, I suggest that the CI pipeline no longer runs on pull requests that modify only the README or other Markdown files only. I've modified the GitHub actions workflow configuration file such that the same rules that applied to pushes before now apply to pull requests as well.