### PR TITLE
Fix #9

### DIFF
--- a/base/Prelude.toml
+++ b/base/Prelude.toml
@@ -189,14 +189,14 @@ exported-values = [
   arity = 1
 
 [[constructors]]
-  haskell-type   = '[a]'
+  haskell-type   = 'Prelude.([]) a'
   haskell-name   = 'Prelude.([])'
   coq-name       = 'nil'
   coq-smart-name = 'Nil'
   arity          = 0
 
 [[constructors]]
-  haskell-type   = 'a -> [a] -> [a]'
+  haskell-type   = 'a -> Prelude.([]) a -> Prelude.([]) a'
   haskell-name   = 'Prelude.(:)'
   coq-name       = 'cons'
   coq-smart-name = 'Cons'
@@ -212,7 +212,7 @@ exported-values = [
   arity        = 2
 
 [[constructors]]
-  haskell-type   = 'a -> b -> (a, b)'
+  haskell-type   = 'a -> b -> Prelude.(,) a b'
   haskell-name   = 'Prelude.(,)'
   coq-name       = 'pair_'
   coq-smart-name = 'Pair_'
@@ -228,7 +228,7 @@ exported-values = [
   arity        = 0
 
 [[constructors]]
-  haskell-type   = '()'
+  haskell-type   = 'Prelude.()'
   haskell-name   = 'Prelude.()'
   coq-name       = 'tt'
   coq-smart-name = 'Tt'

--- a/base/Prelude.toml
+++ b/base/Prelude.toml
@@ -6,7 +6,7 @@
 # Metadata                                                                   #
 ##############################################################################
 
-version = 1
+version = 2
 module-name = 'Prelude'
 library-name = 'Base'
 exported-types = [

--- a/base/Test/QuickCheck.toml
+++ b/base/Test/QuickCheck.toml
@@ -7,7 +7,7 @@
 # Metadata                                                                   #
 ##############################################################################
 
-version = 1
+version = 2
 module-name = 'Test.QuickCheck'
 library-name = 'Base'
 exported-types = [

--- a/src/lib/FreeC/Environment/ModuleInterface/Decoder.hs
+++ b/src/lib/FreeC/Environment/ModuleInterface/Decoder.hs
@@ -139,7 +139,7 @@ import           FreeC.Util.Config
 --   that the implementation of the corresponding change in the other module
 --   is forgotten.
 moduleInterfaceFileFormatVersion :: Integer
-moduleInterfaceFileFormatVersion = 1
+moduleInterfaceFileFormatVersion = 2
 
 -- | Parses an IR AST node from an Aeson string.
 parseAesonIR :: Parseable a => Text -> Aeson.Parser a

--- a/src/lib/FreeC/Environment/ModuleInterface/Encoder.hs
+++ b/src/lib/FreeC/Environment/ModuleInterface/Encoder.hs
@@ -42,7 +42,7 @@ import           FreeC.Util.Config
 --   that the implementation of the corresponding change in the other module
 --   is forgotten.
 moduleInterfaceFileFormatVersion :: Integer
-moduleInterfaceFileFormatVersion = 1
+moduleInterfaceFileFormatVersion = 2
 
 instance Aeson.ToJSON IR.QName where
   toJSON = Aeson.toJSON . showPretty


### PR DESCRIPTION
The problem described in #9 was caused by the changes in b20216bb44a5990f0eff14d0b3fd135473ac2986. Before that commit, the IR pretty-printer supported some syntactic sugar form Haskell. Since the same syntactic sugar is intentionally left out from the IR parser but the pretty-printer should only print valid strings of the intermediate language, the syntactic sugar was removed. The syntax used by IR for Haskell's build-in types is not compatible with the Haskell parser. Since the module interface file decoder was not updated to use the new IR parser instead of the Haskell parser and the incompatible Prelude definitions are always part of module interface files, decoding module interface files failed.