### PR TITLE
Add wrapper module for Agda pretty-printer

### DIFF
--- a/free-compiler.cabal
+++ b/free-compiler.cabal
@@ -102,7 +102,8 @@ common deps
 library freec-internal
   import:             deps
   hs-source-dirs:     src/lib
-  exposed-modules:      FreeC.Backend.Agda.Syntax
+  exposed-modules:      FreeC.Backend.Agda.Pretty
+                      , FreeC.Backend.Agda.Syntax
                       , FreeC.Backend.Coq.Analysis.ConstantArguments
                       , FreeC.Backend.Coq.Analysis.DecreasingArguments
                       , FreeC.Backend.Coq.Base

--- a/src/lib/FreeC/Backend/Agda/Pretty.hs
+++ b/src/lib/FreeC/Backend/Agda/Pretty.hs
@@ -14,22 +14,23 @@ module FreeC.Backend.Agda.Pretty
   )
 where
 
--- We need just he pretty instances from 'Agda.Syntax.Concrete.Pretty'.
+-- We just need the pretty instances from 'Agda.Syntax.Concrete.Pretty'.
 import qualified Agda.Syntax.Concrete.Pretty    ( )
 import qualified Agda.Utils.Pretty             as Agda
 
 import qualified FreeC.Backend.Agda.Syntax     as Agda
 import           FreeC.Pretty
 
+
 -- | Wrapper data type that makes any 'Agda.Pretty' instance pretty printable.
 newtype PrettyAgda a = PrettyAgda { unPrettyAgda :: a }
 
--- | Pretty instance for all Agda internal pretty printable types.
+-- | Pretty instance for all Agda internal, pretty printable types.
 instance (Agda.Pretty a) => Pretty (PrettyAgda a) where
   pretty = prettyString . Agda.prettyShow . unPrettyAgda
 
 -- | Helper function for printing 'Agda.Pretty' printable types @a@ to a 'Doc'
---   used by our pretty printer.
+--   from the pretty printing library, which is used by the compiler.
 prettyAgda :: (Agda.Pretty a) => a -> Doc
 prettyAgda = pretty . PrettyAgda
 
@@ -37,6 +38,6 @@ prettyAgda = pretty . PrettyAgda
 instance Pretty Agda.Expr where
   pretty = prettyAgda
 
--- | 'Agda.Declaration's  are a common AST node.
+-- | 'Agda.Declaration's are a common AST node.
 instance Pretty Agda.Declaration where
   pretty = prettyAgda

--- a/src/lib/FreeC/Backend/Agda/Pretty.hs
+++ b/src/lib/FreeC/Backend/Agda/Pretty.hs
@@ -2,7 +2,7 @@
 
 -- | This module contains 'Pretty' instances for the Agda AST.
 --
---   The Agda has its own 'Agda.Pretty' class in 'Agda.Utils.Pretty'. Therefore
+--   The Agda library has its own 'Agda.Pretty' class in "Agda.Utils.Pretty". Therefore
 --   we cannot instance every @a@ with an @Agda.Pretty@ instance with our
 --   'Pretty' instance without generating overlapping instances for basic types
 --   (e.g. 'String').

--- a/src/lib/FreeC/Backend/Agda/Pretty.hs
+++ b/src/lib/FreeC/Backend/Agda/Pretty.hs
@@ -14,8 +14,6 @@ module FreeC.Backend.Agda.Pretty
   )
 where
 
--- import qualified Agda.Syntax.Concrete.Generic  as Agda
-
 -- We need just he pretty instances from 'Agda.Syntax.Concrete.Pretty'.
 import qualified Agda.Syntax.Concrete.Pretty    ( )
 import qualified Agda.Utils.Pretty             as Agda

--- a/src/lib/FreeC/Backend/Agda/Pretty.hs
+++ b/src/lib/FreeC/Backend/Agda/Pretty.hs
@@ -1,0 +1,44 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- | This module contains 'Pretty' instances for the Agda AST.
+--
+--   The Agda has its own 'Agda.Pretty' class in 'Agda.Utils.Pretty'. Therefore
+--   we cannot instance every @a@ with an @Agda.Pretty@ instance with our
+--   'Pretty' instance without generating overlapping instances for basic types
+--   (e.g. 'String').
+--   We introduce the wrapper datatype 'PrettyAgda' to avoid the overlapping
+--   instances and explicitly declare 'Pretty' instances for for common AST
+--   nodes.
+module FreeC.Backend.Agda.Pretty
+  ( prettyAgda
+  )
+where
+
+-- import qualified Agda.Syntax.Concrete.Generic  as Agda
+
+-- We need just he pretty instances from 'Agda.Syntax.Concrete.Pretty'.
+import qualified Agda.Syntax.Concrete.Pretty    ( )
+import qualified Agda.Utils.Pretty             as Agda
+
+import qualified FreeC.Backend.Agda.Syntax     as Agda
+import           FreeC.Pretty
+
+-- | Wrapper data type that makes any 'Agda.Pretty' instance pretty printable.
+newtype PrettyAgda a = PrettyAgda { unPrettyAgda :: a }
+
+-- | Pretty instance for all Agda internal pretty printable types.
+instance (Agda.Pretty a) => Pretty (PrettyAgda a) where
+  pretty = prettyString . Agda.prettyShow . unPrettyAgda
+
+-- | Helper function for printing 'Agda.Pretty' printable types @a@ to a 'Doc'
+--   used by our pretty printer.
+prettyAgda :: (Agda.Pretty a) => a -> Doc
+prettyAgda = pretty . PrettyAgda
+
+-- | 'Agda.Expr's are a common AST node.
+instance Pretty Agda.Expr where
+  pretty = prettyAgda
+
+-- | 'Agda.Declaration's  are a common AST node.
+instance Pretty Agda.Declaration where
+  pretty = prettyAgda

--- a/src/lib/FreeC/Backend/Agda/Pretty.hs
+++ b/src/lib/FreeC/Backend/Agda/Pretty.hs
@@ -7,7 +7,7 @@
 --   'Pretty' instance without generating overlapping instances for basic types
 --   (e.g. 'String').
 --   We introduce the wrapper datatype 'PrettyAgda' to avoid the overlapping
---   instances and explicitly declare 'Pretty' instances for for common AST
+--   instances and explicitly declare 'Pretty' instances for common AST
 --   nodes.
 module FreeC.Backend.Agda.Pretty
   ( prettyAgda

--- a/src/lib/FreeC/Backend/Agda/Syntax.hs
+++ b/src/lib/FreeC/Backend/Agda/Syntax.hs
@@ -5,12 +5,15 @@ module FreeC.Backend.Agda.Syntax
   ( module Agda.Syntax.Concrete
   , module Agda.Syntax.Common
   , module Agda.Syntax.Position
+    -- * Identifiers
   , name
-  , intLiteral
-  , simpleImport
-  , lambda
   , qname
   , qname'
+    -- * Imports
+  , simpleImport
+    -- * Expressions
+  , intLiteral
+  , lambda
   )
 where
 

--- a/src/lib/FreeC/Backend/Agda/Syntax.hs
+++ b/src/lib/FreeC/Backend/Agda/Syntax.hs
@@ -34,10 +34,10 @@ import qualified Agda.Syntax.Position          as Agda
 name :: String -> Agda.Name
 name ident = Agda.Name Agda.NoRange Agda.InScope [Agda.Id ident]
 
--- | Create a qualified name given a local variable 'Name' and a list of module
---   'Name's.
+-- | Create a qualified identifier given a local identifier as 'Name' and a
+--   list of module 'Name's.
 qname :: [Agda.Name] -> Agda.Name -> QName
-qname ms n = foldr Agda.Qual (Agda.QName n) ms
+qname modules ident = foldr Agda.Qual (Agda.QName ident) modules
 
 -- | Creates a qualified name using an empty list of module names.
 qname' :: Agda.Name -> Agda.QName

--- a/src/lib/FreeC/Backend/Agda/Syntax.hs
+++ b/src/lib/FreeC/Backend/Agda/Syntax.hs
@@ -3,26 +3,58 @@
 
 module FreeC.Backend.Agda.Syntax
   ( module Agda.Syntax.Concrete
+  , module Agda.Syntax.Common
+  , module Agda.Syntax.Position
   , name
   , intLiteral
+  , simpleImport
   , lambda
+  , qname
+  , qname'
   )
 where
 
 import           Agda.Syntax.Concrete
+import           Agda.Syntax.Position
+import           Agda.Syntax.Common
 
 import qualified Agda.Syntax.Common            as Agda
 import qualified Agda.Syntax.Concrete          as Agda
 import qualified Agda.Syntax.Literal           as Agda
 import qualified Agda.Syntax.Position          as Agda
 
+-- | Create a qualified name given a local variable 'Name' and a list of module
+--   'Name's.
+qname :: Agda.Name -> [Agda.Name] -> QName
+qname n = foldr Agda.Qual (Agda.QName n)
 
+-- | Creates a qualified name using an empty list of module names.
+qname' :: Agda.Name -> Agda.QName
+qname' = flip qname []
+
+-- | Creates an @open import@ declaration for the given qualified name.
+--
+--   @open import [modName]@
+simpleImport :: Agda.QName -> Agda.Declaration
+simpleImport modName = Agda.Import
+  Agda.NoRange
+  modName
+  Nothing
+  Agda.DoOpen
+  (Agda.ImportDirective Agda.NoRange Agda.UseEverything [] [] Nothing)
+
+-- | Creates a (not qualified) Agda variable name from a 'String'.
 name :: String -> Agda.Name
 name ident = Agda.Name Agda.NoRange Agda.InScope [Agda.Id ident]
 
+-- | Creates an integer literal.
 intLiteral :: Integer -> Agda.Expr
 intLiteral = Agda.Lit . Agda.LitNat Agda.NoRange
 
+-- | Creates a lambda expression, binding the given names and abstracting the
+--   given expression.
+--
+--   @λ x y … → [expr] @
 lambda :: [Agda.Name] -> Agda.Expr -> Agda.Expr
 lambda args = Agda.Lam
   Agda.NoRange

--- a/src/lib/FreeC/Backend/Agda/Syntax.hs
+++ b/src/lib/FreeC/Backend/Agda/Syntax.hs
@@ -23,6 +23,14 @@ import qualified Agda.Syntax.Concrete          as Agda
 import qualified Agda.Syntax.Literal           as Agda
 import qualified Agda.Syntax.Position          as Agda
 
+-------------------------------------------------------------------------------
+-- Identifiers                                                               --
+-------------------------------------------------------------------------------
+
+-- | Creates a (not qualified) Agda variable name from a 'String'.
+name :: String -> Agda.Name
+name ident = Agda.Name Agda.NoRange Agda.InScope [Agda.Id ident]
+
 -- | Create a qualified name given a local variable 'Name' and a list of module
 --   'Name's.
 qname :: Agda.Name -> [Agda.Name] -> QName
@@ -31,6 +39,10 @@ qname n = foldr Agda.Qual (Agda.QName n)
 -- | Creates a qualified name using an empty list of module names.
 qname' :: Agda.Name -> Agda.QName
 qname' = flip qname []
+
+-------------------------------------------------------------------------------
+-- Imports                                                                   --
+-------------------------------------------------------------------------------
 
 -- | Creates an @open import@ declaration for the given qualified name.
 --
@@ -43,9 +55,9 @@ simpleImport modName = Agda.Import
   Agda.DoOpen
   (Agda.ImportDirective Agda.NoRange Agda.UseEverything [] [] Nothing)
 
--- | Creates a (not qualified) Agda variable name from a 'String'.
-name :: String -> Agda.Name
-name ident = Agda.Name Agda.NoRange Agda.InScope [Agda.Id ident]
+-------------------------------------------------------------------------------
+-- Expressions                                                               --
+-------------------------------------------------------------------------------
 
 -- | Creates an integer literal.
 intLiteral :: Integer -> Agda.Expr

--- a/src/lib/FreeC/Backend/Agda/Syntax.hs
+++ b/src/lib/FreeC/Backend/Agda/Syntax.hs
@@ -36,12 +36,12 @@ name ident = Agda.Name Agda.NoRange Agda.InScope [Agda.Id ident]
 
 -- | Create a qualified name given a local variable 'Name' and a list of module
 --   'Name's.
-qname :: Agda.Name -> [Agda.Name] -> QName
-qname n = foldr Agda.Qual (Agda.QName n)
+qname :: [Agda.Name] -> Agda.Name -> QName
+qname ms n = foldr Agda.Qual (Agda.QName n) ms
 
 -- | Creates a qualified name using an empty list of module names.
 qname' :: Agda.Name -> Agda.QName
-qname' = flip qname []
+qname' = qname []
 
 -------------------------------------------------------------------------------
 -- Imports                                                                   --

--- a/src/lib/FreeC/Backend/Agda/Syntax.hs
+++ b/src/lib/FreeC/Backend/Agda/Syntax.hs
@@ -3,7 +3,27 @@
 
 module FreeC.Backend.Agda.Syntax
   ( module Agda.Syntax.Concrete
+  , name
+  , intLiteral
+  , lambda
   )
 where
 
 import           Agda.Syntax.Concrete
+
+import qualified Agda.Syntax.Common            as Agda
+import qualified Agda.Syntax.Concrete          as Agda
+import qualified Agda.Syntax.Literal           as Agda
+import qualified Agda.Syntax.Position          as Agda
+
+
+name :: String -> Agda.Name
+name ident = Agda.Name Agda.NoRange Agda.InScope [Agda.Id ident]
+
+intLiteral :: Integer -> Agda.Expr
+intLiteral = Agda.Lit . Agda.LitNat Agda.NoRange
+
+lambda :: [Agda.Name] -> Agda.Expr -> Agda.Expr
+lambda args = Agda.Lam
+  Agda.NoRange
+  (Agda.DomainFree . Agda.defaultNamedArg . Agda.mkBinder_ <$> args)

--- a/src/lib/FreeC/Backend/Agda/Syntax.hs
+++ b/src/lib/FreeC/Backend/Agda/Syntax.hs
@@ -17,30 +17,26 @@ module FreeC.Backend.Agda.Syntax
   )
 where
 
-import           Agda.Syntax.Concrete
-import           Agda.Syntax.Position
 import           Agda.Syntax.Common
-
-import qualified Agda.Syntax.Common            as Agda
-import qualified Agda.Syntax.Concrete          as Agda
-import qualified Agda.Syntax.Literal           as Agda
-import qualified Agda.Syntax.Position          as Agda
+import           Agda.Syntax.Concrete
+import           Agda.Syntax.Literal
+import           Agda.Syntax.Position
 
 -------------------------------------------------------------------------------
 -- Identifiers                                                               --
 -------------------------------------------------------------------------------
 
 -- | Creates a (not qualified) Agda variable name from a 'String'.
-name :: String -> Agda.Name
-name ident = Agda.Name Agda.NoRange Agda.InScope [Agda.Id ident]
+name :: String -> Name
+name ident = Name NoRange InScope [Id ident]
 
 -- | Create a qualified identifier given a local identifier as 'Name' and a
 --   list of module 'Name's.
-qname :: [Agda.Name] -> Agda.Name -> QName
-qname modules ident = foldr Agda.Qual (Agda.QName ident) modules
+qname :: [Name] -> Name -> QName
+qname modules ident = foldr Qual (QName ident) modules
 
 -- | Creates a qualified name using an empty list of module names.
-qname' :: Agda.Name -> Agda.QName
+qname' :: Name -> QName
 qname' = qname []
 
 -------------------------------------------------------------------------------
@@ -50,27 +46,25 @@ qname' = qname []
 -- | Creates an @open import@ declaration for the given qualified name.
 --
 --   @open import [modName]@
-simpleImport :: Agda.QName -> Agda.Declaration
-simpleImport modName = Agda.Import
-  Agda.NoRange
+simpleImport :: QName -> Declaration
+simpleImport modName = Import
+  NoRange
   modName
   Nothing
-  Agda.DoOpen
-  (Agda.ImportDirective Agda.NoRange Agda.UseEverything [] [] Nothing)
+  DoOpen
+  (ImportDirective NoRange UseEverything [] [] Nothing)
 
 -------------------------------------------------------------------------------
 -- Expressions                                                               --
 -------------------------------------------------------------------------------
 
 -- | Creates an integer literal.
-intLiteral :: Integer -> Agda.Expr
-intLiteral = Agda.Lit . Agda.LitNat Agda.NoRange
+intLiteral :: Integer -> Expr
+intLiteral = Lit . LitNat NoRange
 
 -- | Creates a lambda expression, binding the given names and abstracting the
 --   given expression.
 --
 --   @λ x y … → [expr] @
-lambda :: [Agda.Name] -> Agda.Expr -> Agda.Expr
-lambda args = Agda.Lam
-  Agda.NoRange
-  (Agda.DomainFree . Agda.defaultNamedArg . Agda.mkBinder_ <$> args)
+lambda :: [Name] -> Expr -> Expr
+lambda args = Lam NoRange (DomainFree . defaultNamedArg . mkBinder_ <$> args)


### PR DESCRIPTION
Adds a `Pretty` instance for Agda AST nodes, as well as some (provisional) smart constructors in `FreeC.Backend.Agda.Syntax` to test the pretty printer. These constructors will probably change when work on #31 starts. Closes #29 