### PR TITLE
Fix unification of rigid type variables

### DIFF
--- a/src/lib/FreeC/Backend/Coq/Converter/FuncDecl/Rec/WithSections.hs
+++ b/src/lib/FreeC/Backend/Coq/Converter/FuncDecl/Rec/WithSections.hs
@@ -75,9 +75,9 @@ convertRecFuncDeclsWithSection constArgs decls = do
   -- unique.
   (constArgTypes, mgus) <- mapAndUnzipM (lookupConstArgType argTypeMap)
                                         renamedConstArgs
-  let mgu           = composeSubsts mgus
-      typeArgNames  = Set.toList (Set.unions (map freeTypeVarSet constArgTypes))
-      typeArgIdents = map (fromJust . IR.identFromQName) typeArgNames
+  let mgu = composeSubsts mgus
+      typeArgIdents =
+        Set.toList (Set.unions (map freeTypeVarSet constArgTypes))
 
   -- Apply unificator to rename the type arguments on the right-hand side.
   let renamedDecls' = applySubst mgu renamedDecls
@@ -89,13 +89,11 @@ convertRecFuncDeclsWithSection constArgs decls = do
   -- Test which of the constant arguments is actually used by any function
   -- in the section and which of the type arguments is needed by the types
   -- of used arguments.
-  let
-    isConstArgUsed    = map (flip any sectionDecls . isConstArgUsedBy) constArgs
-    usedConstArgTypes = map snd $ filter fst $ zip isConstArgUsed constArgTypes
-    isTypeArgUsed v = any
-      (Set.member (IR.UnQual (IR.Ident v)) . freeTypeVarSet)
-      usedConstArgTypes
-    usedTypeArgIdents = filter isTypeArgUsed typeArgIdents
+  let isConstArgUsed = map (flip any sectionDecls . isConstArgUsedBy) constArgs
+      usedConstArgTypes =
+        map snd $ filter fst $ zip isConstArgUsed constArgTypes
+      isTypeArgUsed v = any (Set.member v . freeTypeVarSet) usedConstArgTypes
+      usedTypeArgIdents = filter isTypeArgUsed typeArgIdents
 
     -- Remove constant arguments from the type signatures of the renamed
     -- function declarations.

--- a/src/lib/FreeC/Environment/ModuleInterface/Decoder.hs
+++ b/src/lib/FreeC/Environment/ModuleInterface/Decoder.hs
@@ -112,7 +112,6 @@ import           Data.Aeson                     ( (.!=)
                                                 )
 import qualified Data.Aeson                    as Aeson
 import qualified Data.Aeson.Types              as Aeson
-import           Data.Maybe                     ( mapMaybe )
 import qualified Data.Set                      as Set
 import           Data.Text                      ( Text )
 import qualified Data.Text                     as Text
@@ -242,16 +241,15 @@ instance Aeson.FromJSON ModuleInterface where
       coqName      <- obj .: "coq-name"
       coqSmartName <- obj .: "coq-smart-name"
       let (argTypes, returnType) = IR.splitFuncType haskellType arity
-      return ConEntry
-        { entrySrcSpan    = NoSrcSpan
-        , entryArity      = arity
-        , entryTypeArgs   = mapMaybe IR.identFromQName (freeTypeVars returnType)
-        , entryArgTypes   = map Just argTypes
-        , entryReturnType = Just returnType
-        , entryIdent      = coqName
-        , entrySmartIdent = coqSmartName
-        , entryName       = haskellName
-        }
+      return ConEntry { entrySrcSpan    = NoSrcSpan
+                      , entryArity      = arity
+                      , entryTypeArgs   = freeTypeVars returnType
+                      , entryArgTypes   = map Just argTypes
+                      , entryReturnType = Just returnType
+                      , entryIdent      = coqName
+                      , entrySmartIdent = coqSmartName
+                      , entryName       = haskellName
+                      }
 
     parseConfigFunc :: Aeson.Value -> Aeson.Parser EnvEntry
     parseConfigFunc = Aeson.withObject "Function" $ \obj -> do
@@ -263,7 +261,7 @@ instance Aeson.FromJSON ModuleInterface where
       coqName        <- obj .: "coq-name"
       -- TODO this does not work with vanishing type arguments.
       let (argTypes, returnType) = IR.splitFuncType haskellType arity
-          typeArgs = mapMaybe IR.identFromQName (freeTypeVars haskellType)
+          typeArgs               = freeTypeVars haskellType
       return FuncEntry { entrySrcSpan       = NoSrcSpan
                        , entryArity         = arity
                        , entryTypeArgs      = typeArgs

--- a/src/lib/FreeC/Frontend/Haskell/Simplifier.hs
+++ b/src/lib/FreeC/Frontend/Haskell/Simplifier.hs
@@ -26,6 +26,7 @@ where
 import           Control.Monad                  ( unless
                                                 , when
                                                 )
+import           Data.Composition               ( (.:) )
 import           Data.List.Extra                ( concatUnzip3 )
 import           Data.Maybe                     ( fromJust
                                                 , fromMaybe
@@ -39,6 +40,7 @@ import           FreeC.Frontend.IR.PragmaParser
 import qualified FreeC.IR.Base.Prelude         as IR.Prelude
 import           FreeC.IR.Reference             ( freeTypeVars )
 import           FreeC.IR.SrcSpan
+import           FreeC.IR.Subterm               ( findFirstSubterm )
 import qualified FreeC.IR.Syntax               as IR
 import           FreeC.Monad.Converter
 import           FreeC.Monad.Reporter
@@ -480,9 +482,30 @@ simplifyTypeSchema (HSE.TyForall srcSpan (Just binds) Nothing typeExpr) = do
 -- Without explicit @forall@.
 simplifyTypeSchema typeExpr = do
   typeExpr' <- simplifyType typeExpr
-  let srcSpan  = IR.typeSrcSpan typeExpr'
-      typeArgs = map (IR.TypeVarDecl NoSrcSpan) (freeTypeVars typeExpr')
+  let srcSpan         = IR.typeSrcSpan typeExpr'
+      typeArgIdents   = freeTypeVars typeExpr'
+      typeArgSrcSpans = map (findTypeArgSrcSpan typeExpr') typeArgIdents
+      typeArgs        = zipWith IR.TypeVarDecl typeArgSrcSpans typeArgIdents
   return (IR.TypeSchema srcSpan typeArgs typeExpr')
+ where
+  -- | Finds the first occurrence of the type variable with the given name.
+  --
+  --   Returns 'NoSrcSpan' if 'findTypeArgSrcSpan'' returns @Nothing@.
+  --   Since the type arguments have been extracted using 'freeTypeVars',
+  --   'findTypeArgSrcSpan'' should never return @Nothing@.
+  findTypeArgSrcSpan :: IR.Type -> IR.TypeVarIdent -> SrcSpan
+  findTypeArgSrcSpan = fromMaybe NoSrcSpan .: flip findTypeArgSrcSpan'
+
+  -- | Like 'findTypeArgSrcSpan' but returns @Nothing@ if there is
+  --   no such type variable.
+  findTypeArgSrcSpan' :: IR.TypeVarIdent -> IR.Type -> Maybe SrcSpan
+  findTypeArgSrcSpan' = fmap IR.typeSrcSpan .: findFirstSubterm . isTypeVar
+
+  -- | Tests whether the given type is the type variable with the given name.
+  isTypeVar :: IR.TypeVarIdent -> IR.Type -> Bool
+  isTypeVar typeVarIdent (IR.TypeVar _ typeVarIdent') =
+    typeVarIdent == typeVarIdent'
+  isTypeVar _ _ = False
 
 -- | Simplifies the a type expression.
 simplifyType :: HSE.Type SrcSpan -> Simplifier IR.Type

--- a/src/lib/FreeC/Frontend/Haskell/Simplifier.hs
+++ b/src/lib/FreeC/Frontend/Haskell/Simplifier.hs
@@ -481,9 +481,7 @@ simplifyTypeSchema (HSE.TyForall srcSpan (Just binds) Nothing typeExpr) = do
 simplifyTypeSchema typeExpr = do
   typeExpr' <- simplifyType typeExpr
   let srcSpan  = IR.typeSrcSpan typeExpr'
-      typeArgs = map
-        (IR.TypeVarDecl NoSrcSpan . fromJust . IR.identFromQName)
-        (freeTypeVars typeExpr')
+      typeArgs = map (IR.TypeVarDecl NoSrcSpan) (freeTypeVars typeExpr')
   return (IR.TypeSchema srcSpan typeArgs typeExpr')
 
 -- | Simplifies the a type expression.

--- a/src/lib/FreeC/IR/DependencyGraph.hs
+++ b/src/lib/FreeC/IR/DependencyGraph.hs
@@ -245,6 +245,7 @@ instance Pretty (DependencyGraph node) where
 data DependencyComponent decl
   = NonRecursive decl -- ^ A single non-recursive declaration.
   | Recursive [decl]  -- ^ A list of mutually recursive declarations.
+ deriving Show
 
 -- | Gets the declarations wrapped by the given strongly connected component.
 unwrapComponent :: DependencyComponent decl -> [decl]
@@ -337,3 +338,19 @@ mapComponentM_
   :: MonadFail m => ([decl] -> m a) -> DependencyComponent decl -> m ()
 mapComponentM_ f (NonRecursive decl ) = void (f [decl])
 mapComponentM_ f (Recursive    decls) = void (f decls)
+
+-------------------------------------------------------------------------------
+-- Pretty print SCCs                                                         --
+-------------------------------------------------------------------------------
+
+-- | Pretty instance that pretty prints the declarations of a strongly
+--   connected component.
+--
+--   Each declaration is on its own line and indented by two spaces.
+--   The first line of the document indicates whether the component
+--   was recursive or not.
+instance Pretty decl => Pretty (DependencyComponent decl) where
+  pretty (NonRecursive decl) =
+    prettyString "non-recursive" <$$> indent 2 (pretty decl)
+  pretty (Recursive decls) =
+    prettyString "recursive" <$$> indent 2 (vcat (map pretty decls))

--- a/src/lib/FreeC/IR/Reference.hs
+++ b/src/lib/FreeC/IR/Reference.hs
@@ -31,6 +31,7 @@ where
 import           Data.Composition               ( (.:) )
 import qualified Data.Foldable                 as OSet
                                                 ( toList )
+import           Data.Maybe                     ( fromJust )
 import           Data.Set                       ( Set )
 import qualified Data.Set                      as Set
 import           Data.Set.Ordered               ( OSet
@@ -92,6 +93,12 @@ refScope = fst . unwrapRef
 -- | Unwraps the given reference and discards the scope information.
 refName :: Ref -> IR.QName
 refName = snd . unwrapRef
+
+-- | Like 'refName' but unwraps the identifier of the name.
+--
+--   Fails if the given reference is a symbol.
+refIdent :: Ref -> String
+refIdent = fromJust . IR.identFromQName . refName
 
 -------------------------------------------------------------------------------
 -- Reference sets                                                            --
@@ -286,13 +293,13 @@ withoutArgs args set =
 -------------------------------------------------------------------------------
 
 -- | The type variables that occur freely in the given node from left to right.
-freeTypeVars :: HasRefs a => a -> [IR.QName]
-freeTypeVars = map refName . filter (isVarRef .&&. isTypeRef) . refs
+freeTypeVars :: HasRefs a => a -> [IR.TypeVarIdent]
+freeTypeVars = map refIdent . filter (isVarRef .&&. isTypeRef) . refs
 
 -- | The type variables that occur freely in the given node.
-freeTypeVarSet :: HasRefs a => a -> Set IR.QName
+freeTypeVarSet :: HasRefs a => a -> Set IR.TypeVarIdent
 freeTypeVarSet =
-  Set.map refName . Set.filter (isVarRef .&&. isTypeRef) . OSet.toSet . refSet
+  Set.map refIdent . Set.filter (isVarRef .&&. isTypeRef) . OSet.toSet . refSet
 
 -------------------------------------------------------------------------------
 -- Free variables                                                            --

--- a/src/lib/FreeC/IR/Subterm.hs
+++ b/src/lib/FreeC/IR/Subterm.hs
@@ -25,6 +25,7 @@ module FreeC.IR.Subterm
     -- * Searching for subterms
   , findSubtermPos
   , findSubterms
+  , findFirstSubterm
     -- * Bound variables
   , boundVarsAt
   , boundVarsWithTypeAt
@@ -37,6 +38,7 @@ import           Data.List                      ( intersperse
                                                 )
 import           Data.Maybe                     ( fromJust
                                                 , fromMaybe
+                                                , listToMaybe
                                                 )
 import           Data.Map.Strict                ( Map )
 import qualified Data.Map.Strict               as Map
@@ -260,6 +262,13 @@ findSubtermPos predicate term =
 findSubterms :: Subterm a => (a -> Bool) -> a -> [a]
 findSubterms predicate term =
   filter predicate (map (fromJust . selectSubterm term) (allPos term))
+
+-- | Gets the first subterm of the given expression that satisfies the
+--   provided predicate.
+--
+--   Return @Nothing@ if there is no such subterm.
+findFirstSubterm :: Subterm a => (a -> Bool) -> a -> Maybe a
+findFirstSubterm = listToMaybe .: findSubterms
 
 -------------------------------------------------------------------------------
 -- Bound variables                                                           --

--- a/src/lib/FreeC/Pass/TypeInferencePass.hs
+++ b/src/lib/FreeC/Pass/TypeInferencePass.hs
@@ -226,7 +226,7 @@ typeInferencePass = mapComponentM inferFuncDeclTypes
 -------------------------------------------------------------------------------
 
 -- | A type equation and the location in the source that caused the creation
---   of this type variable.
+--   of this type equation.
 type TypeEquation = (SrcSpan, IR.Type, IR.Type)
 
 -- | Maps the names of defined functions and constructors to their type schema.
@@ -251,7 +251,7 @@ emptyTypeInferenceState = TypeInferenceState { typeEquations  = []
                                              , fixedTypeArgs  = Map.empty
                                              }
 
--- | Creates a 'TypeAssumption' for all funtions and constructors defined
+-- | Creates a 'TypeAssumption' for all functions and constructors defined
 --   in the given environment.
 makeTypeAssumption :: Environment -> TypeAssumption
 makeTypeAssumption env = Map.fromList
@@ -347,7 +347,7 @@ extendTypeAssumptionWithVarPat varPat = mapM_
   (IR.varPatType varPat)
 
 -- | Removes the variable bound by the given variable pattern from the
---   type assumption while runnign the given type inference.
+--   type assumption while running the given type inference.
 removeVarPatFromTypeAssumption :: IR.VarPat -> TypeInference ()
 removeVarPatFromTypeAssumption varPat = modify $ \s ->
   s { typeAssumption = Map.delete (IR.varPatQName varPat) (typeAssumption s) }
@@ -362,7 +362,7 @@ fixTypeArgs name subst =
 -- Scoping                                                                   --
 -------------------------------------------------------------------------------
 
--- | Runs the given type inference and discards all modifications o fthe
+-- | Runs the given type inference and discards all modifications of the
 --   state afterwards.
 withLocalState :: TypeInference a -> TypeInference a
 withLocalState mx = do
@@ -599,7 +599,7 @@ annotateExprWith' (IR.Case srcSpan scrutinee alts _) resType = do
       rhs' <- annotateExprWith rhs resType
       return (IR.Alt altSrcSpan conPat varPats' rhs')
 
--- Error terms are predefined polymorphic funtions. They can be annoated
+-- Error terms are predefined polymorphic funtions. They can be annotated
 -- with the given result type directly.
 annotateExprWith' (IR.Undefined srcSpan _) resType =
   return (IR.Undefined srcSpan (makeExprType resType))
@@ -768,7 +768,7 @@ applyFuncDeclVisibly funcDecl = withLocalTypeAssumption $ do
 --   occur in the function declaration's type and on its right-hand side.
 --
 --   Fresh type variables used by the given type are replaced by regular type
---   varibales with the prefix 'freshTypeArgPrefix'. All other type variables
+--   variables with the prefix 'freshTypeArgPrefix'. All other type variables
 --   are not renamed.
 abstractTypeArgs :: [IR.TypeVarIdent] -> IR.FuncDecl -> IR.FuncDecl
 abstractTypeArgs typeArgIdents funcDecl =
@@ -858,7 +858,7 @@ abstractVanishingTypeArgs funcDecls =
         expr'      = addInternalTypeArgsToExpr funcNames' expr
     in  (IR.Lambda srcSpan args expr' exprType, [])
 
-  -- Leave all other expressions unchnaged.
+  -- Leave all other expressions unchanged.
   addInternalTypeArgsToExpr' _ expr@(IR.Con        _ _ _) = (expr, [])
   addInternalTypeArgsToExpr' _ expr@(IR.IntLiteral _ _ _) = (expr, [])
   addInternalTypeArgsToExpr' _ expr@(IR.Undefined _ _   ) = (expr, [])

--- a/src/lib/FreeC/Pass/TypeInferencePass.hs
+++ b/src/lib/FreeC/Pass/TypeInferencePass.hs
@@ -435,8 +435,6 @@ inferFuncDeclTypes' funcDecls = withLocalState $ do
   -- literal. Thus, the mgu would map the type variable @α@ to @Integer@.
   -- By applying the mgu, the type annotation of @e₁ e₂@ is corrected to
   -- @Integer -> mgu(τ)@.
-  --
-  -- The type equations are unified in reverse order to improve error messages.
   eqns               <- gets typeEquations
   mgu                <- liftConverter $ unifyEquations eqns
   let typedFuncDecls = applySubst mgu annotatedFuncDecls
@@ -902,7 +900,7 @@ unifyEquations = unifyEquations' identitySubst . reverse
     unifyEquations' subst' eqns
 
 -------------------------------------------------------------------------------
--- Solving type equations                                                    --
+-- Rigid type variables                                                      --
 -------------------------------------------------------------------------------
 
 -- | Invokes 'bindRigidTypeVar' for each type variable of the given function

--- a/src/lib/FreeC/Pass/TypeInferencePass.hs
+++ b/src/lib/FreeC/Pass/TypeInferencePass.hs
@@ -18,7 +18,7 @@
 --   function, the types of all argument patterns and the return type of
 --   the function are annotated by this pass.
 --
---   > double (x :: Integer) = x + x :: Integer
+--   > double (x :: Integer) :: Integer = x + x
 --
 --   == Example 2: Polymorphic functions
 --
@@ -61,7 +61,7 @@
 --   Thus, the list contains elements of some type @t0@ which needs to be
 --   added as a type argument to the list constructor @[]@ and @null@.
 --
---   > myTrue @t0 = null @t0 ([] @t0) :: Bool
+--   > myTrue @t0 :: Bool = null @t0 ([] @t0)
 --
 --   While Haskell would tolerate the definition of @myTrue@ without type
 --   arguments, Coq does not accept an equivalent definition.

--- a/src/test/FreeC/IR/ReferenceTests.hs
+++ b/src/test/FreeC/IR/ReferenceTests.hs
@@ -5,7 +5,6 @@ module FreeC.IR.ReferenceTests where
 import           Test.Hspec
 
 import           FreeC.IR.Reference
-import qualified FreeC.IR.Syntax               as IR
 import           FreeC.Test.Parser
 
 -- | Test group for "FreeC.IR.Reference" tests.
@@ -18,11 +17,4 @@ testTypeVars :: Spec
 testTypeVars = context "freeTypeVars" $ do
   it "should preserve the order of type arguments" $ do
     typeExpr <- expectParseTestType "C b ((c -> f) -> (e -> d)) a"
-    freeTypeVars typeExpr
-      `shouldBe` [ IR.UnQual (IR.Ident "b")
-                 , IR.UnQual (IR.Ident "c")
-                 , IR.UnQual (IR.Ident "f")
-                 , IR.UnQual (IR.Ident "e")
-                 , IR.UnQual (IR.Ident "d")
-                 , IR.UnQual (IR.Ident "a")
-                 ]
+    freeTypeVars typeExpr `shouldBe` ["b", "c", "f", "e", "d", "a"]

--- a/src/test/FreeC/IR/UnificationTests.hs
+++ b/src/test/FreeC/IR/UnificationTests.hs
@@ -161,6 +161,15 @@ shouldFailUnification t s = do
         ++ "` and `"
         ++ showPretty s
         ++ "`."
+    Left (RigidTypeVarError _ _ _) ->
+      return
+        $  expectationFailure
+        $  "Expected unification error, but unification failed due to "
+        ++ "matching of a rigid type variable in unification of `"
+        ++ showPretty t
+        ++ "` and `"
+        ++ showPretty s
+        ++ "`."
     Right mgu ->
       return
         $  expectationFailure
@@ -183,6 +192,15 @@ shouldFailOccursCheck t s = do
       return
         $  expectationFailure
         $  "Expected occurs check to fail, but got unification error for `"
+        ++ showPretty t
+        ++ "` and `"
+        ++ showPretty s
+        ++ "`."
+    Left (RigidTypeVarError _ _ _) ->
+      return
+        $  expectationFailure
+        $  "Expected occurs check to fail, but unification failed due to "
+        ++ "matching of a rigid type variable in unification of `"
         ++ showPretty t
         ++ "` and `"
         ++ showPretty s

--- a/src/test/FreeC/Monad/Class/Testable.hs
+++ b/src/test/FreeC/Monad/Class/Testable.hs
@@ -12,6 +12,7 @@ module FreeC.Monad.Class.Testable
   , shouldSucceedWith
     -- * Expecting failures
   , shouldFail
+  , shouldFailPretty
   , shouldFailWith
     -- * QuickCheck
   , shouldReturnProperty
@@ -83,13 +84,22 @@ shouldSucceedWith = flip (shouldReturnWith' (const "<expectation>")) id
 -- | Sets the expectation that the given computation fails without returning
 --   a value.
 shouldFail :: (Show a, MonadTestable m err) => m a -> Expectation
-shouldFail = flip shouldFailWith (const (return ()))
+shouldFail = flip shouldFailWith expectAnyError
+
+-- | Like 'shouldFail' but if the given computation does not fail, the
+--   produced value is printed using its 'Pretty' instance.
+shouldFailPretty :: (Pretty a, MonadTestable m err) => m a -> Expectation
+shouldFailPretty mx = shouldFailWith' showPretty mx expectAnyError
 
 -- | Sets the expectation returned by the given function for the error
 --   that was produced by the given computation instead of a value.
 shouldFailWith
   :: (Show a, MonadTestable m err) => m a -> (err -> Expectation) -> Expectation
 shouldFailWith = shouldFailWith' show
+
+-- | Auxillary function for 'shouldFailWith' that allows arbitrary errors.
+expectAnyError :: err -> Expectation
+expectAnyError = const (return ())
 
 -------------------------------------------------------------------------------
 -- Instances for common pure monads                                          --

--- a/src/test/FreeC/Monad/Class/Testable.hs
+++ b/src/test/FreeC/Monad/Class/Testable.hs
@@ -97,7 +97,7 @@ shouldFailWith
   :: (Show a, MonadTestable m err) => m a -> (err -> Expectation) -> Expectation
 shouldFailWith = shouldFailWith' show
 
--- | Auxillary function for 'shouldFailWith' that allows arbitrary errors.
+-- | Auxiliary function for 'shouldFailWith' that allows arbitrary errors.
 expectAnyError :: err -> Expectation
 expectAnyError = const (return ())
 

--- a/src/test/FreeC/Pass/TypeInferencePassTests.hs
+++ b/src/test/FreeC/Pass/TypeInferencePassTests.hs
@@ -231,7 +231,9 @@ testTypeInferencePass = describe "FreeC.Analysis.TypeInference" $ do
             (NonRecursive "true = eq Nil Nil")
             ["true @a :: Prelude.Bool = eq @(List a) (Nil @a) (Nil @a)"]
     it
-        "infers vanishing type arguments correctly in non-recursive functions that use functions with vanishing type arguments"
+        (  "infers vanishing type arguments correctly in non-recursive "
+        ++ "functions that use functions with vanishing type arguments"
+        )
       $ shouldSucceedWith
       $ do
           _ <- defineTestTypeCon "Prelude.Bool" 0
@@ -289,7 +291,9 @@ testTypeInferencePass = describe "FreeC.Analysis.TypeInference" $ do
               ++ "  }"
             ]
     it
-        "infers vanishing type arguments correctly in recursive functions that use functions with vanishing type arguments"
+        (  "infers vanishing type arguments correctly in recursive functions "
+        ++ "that use functions with vanishing type arguments"
+        )
       $ shouldSucceedWith
       $ do
           _ <- defineTestTypeCon "Prelude.Integer" 0
@@ -344,7 +348,9 @@ testTypeInferencePass = describe "FreeC.Analysis.TypeInference" $ do
             ++ "  }"
             ]
     it
-        "infers vanishing type arguments correctly in mutually recursive functions"
+        (  "infers vanishing type arguments correctly in mutually recursive "
+        ++ "functions"
+        )
       $ shouldSucceedWith
       $ do
           _ <- defineTestTypeCon "Prelude.Integer" 0
@@ -365,19 +371,23 @@ testTypeInferencePass = describe "FreeC.Analysis.TypeInference" $ do
               ++ "  }"
               ]
             )
-            [ "length @a @b @c (xs :: List a) :: Prelude.Integer = case xs of {"
-            ++ "    Nil -> if eq @(List b) (Nil @b) (Nil @b) then 0 else 1;"
-            ++ "    Cons (x :: a) (xs' :: List a) ->"
-            ++ "      succ (length' @a @b @c xs')"
-            ++ "  }"
-            , "length' @a @b @c (xs :: List a) :: Prelude.Integer = case xs of {"
-            ++ "    Nil -> if eq @(List c) (Nil @c) (Nil @c) then 0 else 1;"
-            ++ "    Cons (x :: a) (xs' :: List a) ->"
-            ++ "      succ (length @a @b @c xs')"
-            ++ "  }"
+            [ "length @a @b @c (xs :: List a) :: Prelude.Integer"
+            ++ "  = case xs of {"
+            ++ "      Nil -> if eq @(List b) (Nil @b) (Nil @b) then 0 else 1;"
+            ++ "      Cons (x :: a) (xs' :: List a) ->"
+            ++ "        succ (length' @a @b @c xs')"
+            ++ "    }"
+            , "length' @a @b @c (xs :: List a) :: Prelude.Integer"
+            ++ "  = case xs of {"
+            ++ "      Nil -> if eq @(List c) (Nil @c) (Nil @c) then 0 else 1;"
+            ++ "      Cons (x :: a) (xs' :: List a) ->"
+            ++ "        succ (length @a @b @c xs')"
+            ++ "    }"
             ]
     it
-        "infers vanishing type arguments correctly in mutually recursive functions that use functions with vanishing type arguments"
+        (  "infers vanishing type arguments correctly in mutually recursive "
+        ++ "functions that use functions with vanishing type arguments"
+        )
       $ shouldSucceedWith
       $ do
           _ <- defineTestTypeCon "Prelude.Integer" 0
@@ -398,16 +408,18 @@ testTypeInferencePass = describe "FreeC.Analysis.TypeInference" $ do
               ++ "  }"
               ]
             )
-            [ "length @a @b @c (xs :: List a) :: Prelude.Integer = case xs of {"
-            ++ "    Nil -> if true @b then 0 else 1;"
-            ++ "    Cons (x :: a) (xs' :: List a) ->"
-            ++ "      succ (length' @a @b @c xs')"
-            ++ "  }"
-            , "length' @a @b @c (xs :: List a) :: Prelude.Integer = case xs of {"
-            ++ "    Nil -> if true @c then 0 else 1;"
-            ++ "    Cons (x :: a) (xs' :: List a) ->"
-            ++ "      succ (length @a @b @c xs')"
-            ++ "  }"
+            [ "length @a @b @c (xs :: List a) :: Prelude.Integer"
+            ++ "  = case xs of {"
+            ++ "      Nil -> if true @b then 0 else 1;"
+            ++ "      Cons (x :: a) (xs' :: List a) ->"
+            ++ "        succ (length' @a @b @c xs')"
+            ++ "    }"
+            , "length' @a @b @c (xs :: List a) :: Prelude.Integer"
+            ++ "  = case xs of {"
+            ++ "      Nil -> if true @c then 0 else 1;"
+            ++ "      Cons (x :: a) (xs' :: List a) ->"
+            ++ "        succ (length @a @b @c xs')"
+            ++ "    }"
             ]
 
   context "functions type signatures" $ do

--- a/src/test/FreeC/Pass/TypeInferencePassTests.hs
+++ b/src/test/FreeC/Pass/TypeInferencePassTests.hs
@@ -202,7 +202,7 @@ testTypeInferencePass = describe "FreeC.Analysis.TypeInference" $ do
                       ["f :: Bar = unfoo @Bar (Foo @Bar)"]
 
   context "non-recursive functions" $ do
-    it "infers the types of simple simple non-recursive correctly"
+    it "infers the types of simple non-recursive functions correctly"
       $ shouldSucceedWith
       $ do
           _ <- defineTestTypeCon "Bool" 0


### PR DESCRIPTION
The unification algorithm that is used by the type inference pass was extended to report a fatal error if a rigid type variable bound by the type signature of a function is matched with another type. Closes #13 