### PR TITLE
Implement error effect in Coq #18

### DIFF
--- a/base/Free/Instance/Error.v
+++ b/base/Free/Instance/Error.v
@@ -1,5 +1,7 @@
 (** * Definition of the error monad in terms of the free monad. *)
 
+Require Import Coq.Strings.String.
+
 From Base Require Import Free.
 From Base Require Import Free.Util.Void.
 
@@ -16,7 +18,13 @@ Module Error.
       impure msg (fun (p : Pos msg) => match p with end).
   End Monad.
 
-  (* TODO Partial instance for the error monad. *)
+  (* Partial instance for the error monad. *)
+  Open Scope string_scope.
+  Instance Partial : Partial  (Shape string) Pos := {
+    undefined := fun {A : Type}                => ThrowError "undefined";
+    error     := fun {A : Type} (msg : string) => ThrowError msg
+  }.
+  Close Scope string_scope.
 End Error.
 
 (* The type and smart constructor should be visible to other modules

--- a/base/Free/Instance/Error.v
+++ b/base/Free/Instance/Error.v
@@ -1,11 +1,12 @@
 (** * Definition of the error monad in terms of the free monad. *)
 
 From Base Require Import Free.
+From Base Require Import Free.Util.Void.
 
 Module Error.
-  (* TODO Container instance that corresponds to [Const]. *)
-  (* Definition Shape : Type := (* ... *). *)
-  (* Definition Pos (s : Shape) : Type := (* ... *). *)
+  (* Container instance that corresponds to [Const]. *)
+  Definition Shape (E : Type) : Type := E.
+  Definition Pos {E : Type} (s : Shape E) : Type := Void.
 
   (* TODO Type synonym and smart constructors for the error monad. *)
   Module Import Monad.

--- a/base/Free/Instance/Error.v
+++ b/base/Free/Instance/Error.v
@@ -20,7 +20,7 @@ Module Error.
 
   (* Partial instance for the error monad. *)
   Open Scope string_scope.
-  Instance Partial : Partial  (Shape string) Pos := {
+  Instance Partial : Partial (Shape string) Pos := {
     undefined := fun {A : Type}                => ThrowError "undefined";
     error     := fun {A : Type} (msg : string) => ThrowError msg
   }.

--- a/base/Free/Instance/Error.v
+++ b/base/Free/Instance/Error.v
@@ -1,7 +1,5 @@
 (** * Definition of the error monad in terms of the free monad. *)
 
-Require Import Coq.Strings.String.
-
 From Base Require Import Free.
 From Base Require Import Free.Util.Void.
 
@@ -19,12 +17,10 @@ Module Error.
   End Monad.
 
   (* Partial instance for the error monad. *)
-  Open Scope string_scope.
   Instance Partial : Partial (Shape string) Pos := {
-    undefined := fun {A : Type}                => ThrowError "undefined";
+    undefined := fun {A : Type}                => ThrowError "undefined"%string;
     error     := fun {A : Type} (msg : string) => ThrowError msg
   }.
-  Close Scope string_scope.
 End Error.
 
 (* The type and smart constructor should be visible to other modules

--- a/base/Free/Instance/Error.v
+++ b/base/Free/Instance/Error.v
@@ -8,9 +8,12 @@ Module Error.
   Definition Shape (E : Type) : Type := E.
   Definition Pos {E : Type} (s : Shape E) : Type := Void.
 
-  (* TODO Type synonym and smart constructors for the error monad. *)
+  (* Type synonym and smart constructors for the error monad. *)
   Module Import Monad.
-
+    Definition Error (E A : Type) := Free (Shape E) Pos A.
+    Definition NoError {E A : Type} (x : A) : Error E A := pure x.
+    Definition ThrowError {E A : Type} (msg : E) : Error E A :=
+      impure msg (fun (p : Pos msg) => match p with end).
   End Monad.
 
   (* TODO Partial instance for the error monad. *)

--- a/base/Free/Instance/Maybe.v
+++ b/base/Free/Instance/Maybe.v
@@ -1,7 +1,5 @@
 (** * Definition of the maybe monad in terms of the free monad. *)
 
-Require Import Coq.Strings.String.
-
 From Base Require Import Free.
 From Base Require Import Free.Util.Void.
 

--- a/example/Proofs/ConsUncons.hs
+++ b/example/Proofs/ConsUncons.hs
@@ -15,7 +15,7 @@ import           Data.List                      ( head )
 
 unconsE :: [a] -> (a, [a])
 unconsE ls = case ls of
-  []       -> error "uncons: empty list"
+  []       -> error "unconsE: empty list"
   (x : xs) -> (x, xs)
 
 -- Next we can define a simple property about this function, e.g., its relation

--- a/example/Proofs/ConsUncons.hs
+++ b/example/Proofs/ConsUncons.hs
@@ -24,7 +24,7 @@ unconsE ls = case ls of
 prop_cons_unconsE :: (Eq a, Show a) => a -> [a] -> Property
 prop_cons_unconsE x xs = unconsE (x : xs) === (x, xs)
 
--- And we define a property thats validity depends on the model used in the proof.
+-- And we define a property whose validity depends on the model used in the proof.
 
 fst :: (a, b) -> a
 fst p = case p of

--- a/example/Proofs/ConsUncons.hs
+++ b/example/Proofs/ConsUncons.hs
@@ -1,0 +1,23 @@
+-- | This example demonstrates how to use the translation of an error
+--   throwing function to prove properties about this function and about the
+--   possible errors that can be thrown.
+--
+--   This example uses an error throwing implementation of the @uncons@
+--   function.
+
+module Proofs.ConsUncons where
+
+import           Test.QuickCheck
+
+-- First we have to define the @uncons@ function in an error throwing way.
+
+unconsE :: [a] -> (a, [a])
+unconsE ls = case ls of
+  []       -> error "uncons: empty list"
+  (x : xs) -> (x, xs)
+
+-- Next we can define a simple property about this function, e.g., its relation
+-- to the constructor of an non-empty list.
+
+prop_cons_unconsE :: (Eq a, Show a) => a -> [a] -> Property
+prop_cons_unconsE x xs = unconsE (x : xs) === (x, xs)

--- a/example/Proofs/ConsUncons.hs
+++ b/example/Proofs/ConsUncons.hs
@@ -2,14 +2,16 @@
 --   throwing function to prove properties about this function and about the
 --   possible errors that can be thrown.
 --
---   This example uses an error throwing implementation of the @uncons@
---   function.
+--   This example uses a function @unconsE@ that is an error throwing version
+--   of the @uncons@ function.
 
 module Proofs.ConsUncons where
 
 import           Test.QuickCheck
 
--- First we have to define the @uncons@ function in an error throwing way.
+import           Data.List                      ( head )
+
+-- First we have to define the @unconsE@ function in an error throwing way.
 
 unconsE :: [a] -> (a, [a])
 unconsE ls = case ls of
@@ -21,3 +23,12 @@ unconsE ls = case ls of
 
 prop_cons_unconsE :: (Eq a, Show a) => a -> [a] -> Property
 prop_cons_unconsE x xs = unconsE (x : xs) === (x, xs)
+
+-- And we define a property thats validity depends on the model used in the proof.
+
+fst :: (a, b) -> a
+fst p = case p of
+  (x, y) -> x
+
+prop_unconsE_fst :: (Eq a, Show a) => [a] -> Property
+prop_unconsE_fst xs = fst (unconsE xs) === head xs

--- a/example/Proofs/ConsUnconsProofs.v
+++ b/example/Proofs/ConsUnconsProofs.v
@@ -1,4 +1,4 @@
-From Base Require Import Free Free.Instance.Maybe Free.Instance.Error Test.QuickCheck Prelude.
+From Base Require Import Free Free.Instance.Error Free.Instance.Maybe Prelude Test.QuickCheck.
 From Generated Require Import Proofs.ConsUncons.
 
 Require Import Coq.Logic.FunctionalExtensionality.
@@ -12,7 +12,7 @@ Proof.
   reflexivity.
 Qed.
 
-(* The second QuickCheck property holds provable for the [Maybe] instance of [Partial]. *)
+(* The second QuickCheck property holds provably for the [Maybe] instance of [Partial]. *)
 Lemma unconsE_fst_Maybe : quickCheck (@prop_unconsE_fst Maybe.Shape Maybe.Pos Maybe.Partial).
 Proof.
   intros A fxs.
@@ -38,16 +38,16 @@ Section ErrorMessages.
 
   (* To prove facts about the error messages we can write an abbreviation for
      an [error] with a specific message. *)
-  Definition EmptyListError {A : Type} := @error _ _ _ A "unconsE: empty list"%string.
+  Definition EmptyListError {A : Type} := @error _ _ Error.Partial A "unconsE: empty list"%string.
 
   (* If we weren't looking for an actual [error] but for an [undefined] in haskell
      we could use the following definition. *)
-  Definition Undefined {A : Type} := @undefined _ _ _ A.
+  Definition Undefined {A : Type} := @undefined _ _ Error.Partial A.
 
   (* Now we can define and prove the lemma that using [unconsE] with an empty
      list results in an [EmptyListError] *)
   Lemma nil_unconsE_empty_list_error : forall (A : Type),
-    @unconsE _ _ _ A (Nil _ _) = EmptyListError.
+    @unconsE _ _ Error.Partial A (Nil _ _) = EmptyListError.
   Proof.
     intro A.
     simpl.
@@ -57,7 +57,7 @@ Section ErrorMessages.
   (* We can also prove that using [unconsE] on an non-empty list does not cause
      an [EmptyListError]. *)
   Lemma cons_unconsE_no_empty_list_error : forall (A : Type) (fx : Free _ _ A) (fxs : Free _ _ (List _ _ A)),
-    unconsE _ _ _ (Cons _ _ fx fxs) <> EmptyListError.
+    unconsE _ _ Error.Partial (Cons _ _ fx fxs) <> EmptyListError.
   Proof.
     intros A fx fxs.
     simpl.
@@ -67,8 +67,8 @@ Section ErrorMessages.
   (* And finally we can prove that an [EmptyListError] is the only error that
      can occur if the argument is error-free. *)
   Lemma unconsE_only_empty_list_error : forall (A : Type) (l : List _ _ A),
-    (exists (result : Pair _ _ A (List _ _ A)), unconsE _ _ _ (NoError l) = NoError result) \/
-    (                                           unconsE _ _ _ (NoError l) = EmptyListError).
+    (exists (result : Pair _ _ A (List _ _ A)), unconsE _ _ Error.Partial (NoError l) = NoError result) \/
+    (                                           unconsE _ _ Error.Partial (NoError l) = EmptyListError).
   Proof.
     intros A l.
     destruct l as [ | fx fxs ].

--- a/example/Proofs/ConsUnconsProofs.v
+++ b/example/Proofs/ConsUnconsProofs.v
@@ -1,28 +1,48 @@
-From Base Require Import Free Free.Instance.Error Test.QuickCheck Prelude.
+From Base Require Import Free Free.Instance.Maybe Free.Instance.Error Test.QuickCheck Prelude.
 From Generated Require Import Proofs.ConsUncons.
 
-(* The proof for the QuickCheck property differs only in that way from proofs
-   about functions that do not return an error, that an [Partial] instance for
-   [Shape] and [Pos] is given. *)
+Require Import Coq.Logic.FunctionalExtensionality.
+
+(* The first QuickCheck property holds for any [Partial] instance. Therefore
+   its proof differs only in that way from proofs about functions that do not
+   return an error, that an [Partial] instance for [Shape] and [Pos] is given. *)
 Lemma cons_unconsE : quickCheck prop_cons_unconsE.
 Proof.
   intros Shape Pos Partial A fx fxs.
   reflexivity.
 Qed.
 
+(* The second QuickCheck property holds provable for the [Maybe] instance of [Partial]. *)
+Lemma unconsE_fst_Maybe : quickCheck (@prop_unconsE_fst Maybe.Shape Maybe.Pos Maybe.Partial).
+Proof.
+  intros A fxs.
+  simpl.
+  destruct fxs as [ xs | s pf ].
+  - destruct xs as [ | fx1 fxs1 ].
+    + simpl. unfold Nothing. f_equal. extensionality p. destruct p.
+    + reflexivity.
+  - simpl. f_equal. extensionality p. destruct p.
+Qed.
+
+(* But the second QuickCheck property doesn't hold for the [Error] instance of
+   [Partial] as [unconsE] and [head] have different error messages on an empty
+   list. *)
+Lemma unconsE_fst_Error : not (quickCheck (@prop_unconsE_fst (Error.Shape string) Error.Pos Error.Partial)).
+Proof.
+  intro H.
+  specialize (H bool (Nil _ _)).
+  discriminate H.
+Qed.
+
 Section ErrorMessages.
 
   (* To prove facts about the error messages we can write an abbreviation for
      an [error] with a specific message. *)
-  Open Scope string_scope.
-  Definition EmptyListError {A : Type} := @error _ _ _ A "uncons: empty list".
-  Close Scope string_scope.
+  Definition EmptyListError {A : Type} := @error _ _ _ A "uncons: empty list"%string.
 
   (* If we weren't looking for an actual [error] but for an [undefined] in haskell
      we could use the following definition. *)
-  Open Scope string_scope.
   Definition Undefined {A : Type} := @undefined _ _ _ A.
-  Close Scope string_scope.
 
   (* Now we can define and prove the lemma that using [unconsE] with an empty
      list results in an [EmptyListError] *)
@@ -36,7 +56,7 @@ Section ErrorMessages.
 
   (* We can also prove that using [unconsE] on an non-empty list does not cause
      an [EmptyListError]. *)
-  Lemma cons_uncons_no_empty_list_error : forall (A : Type) (fx : Free _ _ A) (fxs : Free _ _ (List _ _ A)),
+  Lemma cons_unconsE_no_empty_list_error : forall (A : Type) (fx : Free _ _ A) (fxs : Free _ _ (List _ _ A)),
     unconsE _ _ _ (Cons _ _ fx fxs) <> EmptyListError.
   Proof.
     intros A fx fxs.
@@ -46,7 +66,7 @@ Section ErrorMessages.
 
   (* And finally we can prove that an [EmptyListError] is the only error that
      can occur if the argument is error-free. *)
-  Lemma uncons_only_empty_list_error : forall (A : Type) (l : List _ _ A),
+  Lemma unconsE_only_empty_list_error : forall (A : Type) (l : List _ _ A),
     (exists (result : Pair _ _ A (List _ _ A)), unconsE _ _ _ (NoError l) = NoError result) \/
     (                                           unconsE _ _ _ (NoError l) = EmptyListError).
   Proof.

--- a/example/Proofs/ConsUnconsProofs.v
+++ b/example/Proofs/ConsUnconsProofs.v
@@ -47,7 +47,7 @@ Section ErrorMessages.
   (* Now we can define and prove the lemma that using [unconsE] with an empty
      list results in an [EmptyListError] *)
   Lemma nil_unconsE_empty_list_error : forall (A : Type),
-  @unconsE _ _ _ A (Nil _ _) = EmptyListError.
+    @unconsE _ _ _ A (Nil _ _) = EmptyListError.
   Proof.
     intro A.
     simpl.

--- a/example/Proofs/ConsUnconsProofs.v
+++ b/example/Proofs/ConsUnconsProofs.v
@@ -1,0 +1,58 @@
+From Base Require Import Free Free.Instance.Error Test.QuickCheck Prelude.
+From Generated Require Import Proofs.ConsUncons.
+
+(* The proof for the QuickCheck property differs only in that way from proofs
+   about functions that do not return an error, that an [Partial] instance for
+   [Shape] and [Pos] is given. *)
+Lemma cons_unconsE : quickCheck prop_cons_unconsE.
+Proof.
+  intros Shape Pos Partial A fx fxs.
+  reflexivity.
+Qed.
+
+Section ErrorMessages.
+
+  (* To prove facts about the error messages we can write an abbreviation for
+     an [error] with a specific message. *)
+  Open Scope string_scope.
+  Definition EmptyListError {A : Type} := @error _ _ _ A "uncons: empty list".
+  Close Scope string_scope.
+
+  (* If we weren't looking for an actual [error] but for an [undefined] in haskell
+     we could use the following definition. *)
+  Open Scope string_scope.
+  Definition Undefined {A : Type} := @undefined _ _ _ A.
+  Close Scope string_scope.
+
+  (* Now we can define and prove the lemma that using [unconsE] with an empty
+     list results in an [EmptyListError] *)
+  Lemma nil_unconsE_empty_list_error : forall (A : Type),
+  @unconsE _ _ _ A (Nil _ _) = EmptyListError.
+  Proof.
+    intro A.
+    simpl.
+    reflexivity.
+  Qed.
+
+  (* We can also prove that using [unconsE] on an non-empty list does not cause
+     an [EmptyListError]. *)
+  Lemma cons_uncons_no_empty_list_error : forall (A : Type) (fx : Free _ _ A) (fxs : Free _ _ (List _ _ A)),
+    unconsE _ _ _ (Cons _ _ fx fxs) <> EmptyListError.
+  Proof.
+    intros A fx fxs.
+    simpl.
+    discriminate.
+  Qed.
+
+  (* And finally we can prove that an [EmptyListError] is the only error that
+     can occur if the argument is error-free. *)
+  Lemma uncons_only_empty_list_error : forall (A : Type) (l : List _ _ A),
+    (exists (result : Pair _ _ A (List _ _ A)), unconsE _ _ _ (NoError l) = NoError result) \/
+    (                                           unconsE _ _ _ (NoError l) = EmptyListError).
+  Proof.
+    intros A l.
+    destruct l as [ | fx fxs ].
+    - right. reflexivity.
+    - left. simpl. exists (pair_ fx fxs). reflexivity.
+  Qed.
+End ErrorMessages.

--- a/example/Proofs/ConsUnconsProofs.v
+++ b/example/Proofs/ConsUnconsProofs.v
@@ -38,7 +38,7 @@ Section ErrorMessages.
 
   (* To prove facts about the error messages we can write an abbreviation for
      an [error] with a specific message. *)
-  Definition EmptyListError {A : Type} := @error _ _ _ A "uncons: empty list"%string.
+  Definition EmptyListError {A : Type} := @error _ _ _ A "unconsE: empty list"%string.
 
   (* If we weren't looking for an actual [error] but for an [undefined] in haskell
      we could use the following definition. *)


### PR DESCRIPTION
- Add implementation as described in [here](https://github.com/FreeProving/free-proving-code/blob/master/src/Effects.v).
- Add an example function in haskell that throws an error and a simple QuickCheck property for that function.
- Add proofs concerning error messages in addition to the proof of the QuickCheck property in the corresponding Coq file.