### PR TITLE
Implement translation of type expressions

### DIFF
--- a/base/coq/Prelude.toml
+++ b/base/coq/Prelude.toml
@@ -50,7 +50,7 @@ exported-values = [
 [[types]]
   haskell-name = 'Prelude.Bool'
   coq-name     = 'Bool'
-  agda-name    = 'Bool'
+  agda-name    = '𝔹'
   arity        = 0
 
 [[constructors]]

--- a/free-compiler.cabal
+++ b/free-compiler.cabal
@@ -104,6 +104,7 @@ library freec-internal
   hs-source-dirs:     src/lib
   exposed-modules:      FreeC.Backend.Agda.Base
                       , FreeC.Backend.Agda.Converter
+                      , FreeC.Backend.Agda.Converter.Free
                       , FreeC.Backend.Agda.Converter.FuncDecl
                       , FreeC.Backend.Agda.Converter.Module
                       , FreeC.Backend.Agda.Converter.Type

--- a/free-compiler.cabal
+++ b/free-compiler.cabal
@@ -106,6 +106,7 @@ library freec-internal
                       , FreeC.Backend.Agda.Converter
                       , FreeC.Backend.Agda.Converter.FuncDecl
                       , FreeC.Backend.Agda.Converter.Module
+                      , FreeC.Backend.Agda.Converter.Type
                       , FreeC.Backend.Agda.Pretty
                       , FreeC.Backend.Agda.Syntax
                       , FreeC.Backend.Coq.Analysis.ConstantArguments

--- a/free-compiler.cabal
+++ b/free-compiler.cabal
@@ -103,6 +103,7 @@ library freec-internal
   import:             deps
   hs-source-dirs:     src/lib
   exposed-modules:      FreeC.Backend.Agda.Base
+                      , FreeC.Backend.Agda.Converter
                       , FreeC.Backend.Agda.Converter.FuncDecl
                       , FreeC.Backend.Agda.Converter.Module
                       , FreeC.Backend.Agda.Pretty

--- a/free-compiler.cabal
+++ b/free-compiler.cabal
@@ -103,6 +103,8 @@ library freec-internal
   import:             deps
   hs-source-dirs:     src/lib
   exposed-modules:      FreeC.Backend.Agda.Base
+                      , FreeC.Backend.Agda.Converter.FuncDecl
+                      , FreeC.Backend.Agda.Converter.Module
                       , FreeC.Backend.Agda.Pretty
                       , FreeC.Backend.Agda.Syntax
                       , FreeC.Backend.Coq.Analysis.ConstantArguments

--- a/src/exe/Main.hs
+++ b/src/exe/Main.hs
@@ -148,7 +148,6 @@ convertInputModule haskellAst = do
     agdaAst <- liftConverter $ Agda.convertModule haskellAst
     traceM $ showPretty agdaAst
     traceM "\n--------\n"
-    traceM undefined
     return (modName, coqAst)
 
 -------------------------------------------------------------------------------

--- a/src/exe/Main.hs
+++ b/src/exe/Main.hs
@@ -23,8 +23,6 @@ import           FreeC.Application.Option.Help
 import           FreeC.Application.Option.Version
 import           FreeC.Application.Options
 import           FreeC.Application.Options.Parser
-import qualified FreeC.Backend.Agda.Converter  as Agda
-import           FreeC.Backend.Agda.Pretty      ( )
 import qualified FreeC.Backend.Coq.Base        as Coq.Base
 import           FreeC.Backend.Coq.Converter    ( convertModule )
 import           FreeC.Backend.Coq.Pretty
@@ -51,8 +49,6 @@ import           FreeC.Pretty                   ( putPrettyLn
                                                 , showPretty
                                                 , writePrettyFile
                                                 )
-
-import           Debug.Trace                    ( traceM )
 
 -------------------------------------------------------------------------------
 -- Main                                                                      --
@@ -145,9 +141,6 @@ convertInputModule haskellAst = do
   reportApp $ do
     loadRequiredModules haskellAst
     coqAst  <- liftConverter $ convertModule haskellAst
-    agdaAst <- liftConverter $ Agda.convertModule haskellAst
-    traceM $ showPretty agdaAst
-    traceM "\n--------\n"
     return (modName, coqAst)
 
 -------------------------------------------------------------------------------

--- a/src/exe/Main.hs
+++ b/src/exe/Main.hs
@@ -140,7 +140,7 @@ convertInputModule haskellAst = do
     else putDebug $ "Compiling " ++ showPretty modName
   reportApp $ do
     loadRequiredModules haskellAst
-    coqAst  <- liftConverter $ convertModule haskellAst
+    coqAst <- liftConverter $ convertModule haskellAst
     return (modName, coqAst)
 
 -------------------------------------------------------------------------------

--- a/src/exe/Main.hs
+++ b/src/exe/Main.hs
@@ -23,6 +23,8 @@ import           FreeC.Application.Option.Help
 import           FreeC.Application.Option.Version
 import           FreeC.Application.Options
 import           FreeC.Application.Options.Parser
+import qualified FreeC.Backend.Agda.Converter  as Agda
+import           FreeC.Backend.Agda.Pretty      ( )
 import qualified FreeC.Backend.Coq.Base        as Coq.Base
 import           FreeC.Backend.Coq.Converter    ( convertModule )
 import           FreeC.Backend.Coq.Pretty
@@ -49,6 +51,8 @@ import           FreeC.Pretty                   ( putPrettyLn
                                                 , showPretty
                                                 , writePrettyFile
                                                 )
+
+import           Debug.Trace                    ( traceM )
 
 -------------------------------------------------------------------------------
 -- Main                                                                      --
@@ -140,7 +144,11 @@ convertInputModule haskellAst = do
     else putDebug $ "Compiling " ++ showPretty modName
   reportApp $ do
     loadRequiredModules haskellAst
-    coqAst <- liftConverter $ convertModule haskellAst
+    coqAst  <- liftConverter $ convertModule haskellAst
+    agdaAst <- liftConverter $ Agda.convertModule haskellAst
+    traceM $ showPretty agdaAst
+    traceM "\n--------\n"
+    traceM undefined
     return (modName, coqAst)
 
 -------------------------------------------------------------------------------

--- a/src/lib/FreeC/Backend/Agda/Base.hs
+++ b/src/lib/FreeC/Backend/Agda/Base.hs
@@ -89,7 +89,6 @@ shape = Agda.name "S"
 position :: Agda.Name
 position = Agda.name "P"
 
--- | Adds the @Shape@ and @Position@ type variables to a list of variables.
 addTVars :: [Agda.Name] -> [Agda.Name]
 addTVars ts = shape : position : ts
 

--- a/src/lib/FreeC/Backend/Agda/Base.hs
+++ b/src/lib/FreeC/Backend/Agda/Base.hs
@@ -9,6 +9,7 @@ module FreeC.Backend.Agda.Base
     -- * Free Monad
   , free
   , free'
+  , freeArgs
   , pure
   , impure
   , shape
@@ -45,36 +46,50 @@ imports = Agda.simpleImport $ Agda.qname [baseLibName] $ Agda.name "Free"
 -- Free Monad                                                                --
 -------------------------------------------------------------------------------
 
+-- | Identifier for the @Free@ monad.
 free :: Agda.Name
 free = Agda.name "Free"
 
+-- | Lifts a type in the free monad.
 free' :: Agda.Expr -> Agda.Expr
-free' e = foldl1
+free' = Agda.app $ freeArgs $ Agda.qname' free
+
+-- | Apply the @Shape@ and @Position@ argument to the given type constructor.
+--
+-- > c ↦ c @S @P
+freeArgs :: Agda.QName -> Agda.Expr
+freeArgs qname = foldl1
   Agda.app
-  [ Agda.Ident (Agda.qname' free)
+  [ Agda.Ident qname
   , Agda.Ident (Agda.qname' shape)
   , Agda.Ident (Agda.qname' position)
-  , e
   ]
 
+-- | Identifier for the @Pure@ constructor of the @Free@ monad.
 pureConName :: Agda.Name
 pureConName = Agda.name "pure"
 
+-- | Applies the @Pure@ constructor of the free monad to the given expression.
 pure :: Agda.Expr -> Agda.Expr
 pure = Agda.app $ Agda.Ident $ Agda.qname [Agda.name "Free"] pureConName
 
+-- | Identifier for the @Impure@ constructor of the @Free@ monad.
 impureConName :: Agda.Name
 impureConName = Agda.name "impure"
 
+-- | Applies the @Impure@ constructor of the free monad to the given expression.
 impure :: Agda.Expr -> Agda.Expr
 impure = Agda.app $ Agda.Ident $ Agda.qname [Agda.name "Free"] impureConName
 
+-- | Reserved name for the @Shape@ type variable.
 shape :: Agda.Name
 shape = Agda.name "S"
 
+-- | Reserved name for the @Position@ type variable.
 position :: Agda.Name
 position = Agda.name "P"
 
+-- | Adds the @Shape@ and @Position@ type variables to a list of variables.
 addTVars :: [Agda.Name] -> [Agda.Name]
 addTVars ts = shape : position : ts
 

--- a/src/lib/FreeC/Backend/Agda/Base.hs
+++ b/src/lib/FreeC/Backend/Agda/Base.hs
@@ -8,13 +8,9 @@ module FreeC.Backend.Agda.Base
   , imports
     -- * Free Monad
   , free
-  , free'
-  , freeArgs
   , pure
-  , impure
   , shape
   , position
-  , addTVars
     -- * reserved identifiers
   , reservedIdents
   )
@@ -50,47 +46,21 @@ imports = Agda.simpleImport $ Agda.qname [baseLibName] $ Agda.name "Free"
 free :: Agda.Name
 free = Agda.name "Free"
 
--- | Lifts a type in the free monad.
-free' :: Agda.Expr -> Agda.Expr
-free' = Agda.app $ freeArgs $ Agda.qname' free
+-- | Identifier for the @pure@ constructor of the @Free@ monad.
+pure :: Agda.Name
+pure = Agda.name "pure"
 
--- | Apply the @Shape@ and @Position@ argument to the given type constructor.
---
--- > c ↦ c @S @P
-freeArgs :: Agda.QName -> Agda.Expr
-freeArgs qname = foldl1
-  Agda.app
-  [ Agda.Ident qname
-  , Agda.Ident (Agda.qname' shape)
-  , Agda.Ident (Agda.qname' position)
-  ]
-
--- | Identifier for the @Pure@ constructor of the @Free@ monad.
-pureConName :: Agda.Name
-pureConName = Agda.name "pure"
-
--- | Applies the @Pure@ constructor of the free monad to the given expression.
-pure :: Agda.Expr -> Agda.Expr
-pure = Agda.app $ Agda.Ident $ Agda.qname [Agda.name "Free"] pureConName
-
--- | Identifier for the @Impure@ constructor of the @Free@ monad.
-impureConName :: Agda.Name
-impureConName = Agda.name "impure"
-
--- | Applies the @Impure@ constructor of the free monad to the given expression.
-impure :: Agda.Expr -> Agda.Expr
-impure = Agda.app $ Agda.Ident $ Agda.qname [Agda.name "Free"] impureConName
+-- | Identifier for the @impure@ constructor of the @Free@ monad.
+impure :: Agda.Name
+impure = Agda.name "impure"
 
 -- | Reserved name for the @Shape@ type variable.
 shape :: Agda.Name
-shape = Agda.name "S"
+shape = Agda.name "Shape"
 
--- | Reserved name for the @Position@ type variable.
+-- | Reserved name for the @Pos@ type variable.
 position :: Agda.Name
-position = Agda.name "P"
-
-addTVars :: [Agda.Name] -> [Agda.Name]
-addTVars ts = shape : position : ts
+position = Agda.name "Pos"
 
 -------------------------------------------------------------------------------
 -- Reserved identifiers                                                      --
@@ -100,4 +70,4 @@ addTVars ts = shape : position : ts
 --
 --   This does only include identifiers without corresponding Haskell name.
 reservedIdents :: [Agda.Name]
-reservedIdents = [free, pureConName, impureConName, shape, position]
+reservedIdents = [free, pure, impure, shape, position]

--- a/src/lib/FreeC/Backend/Agda/Base.hs
+++ b/src/lib/FreeC/Backend/Agda/Base.hs
@@ -8,10 +8,12 @@ module FreeC.Backend.Agda.Base
   , imports
     -- * Free Monad
   , free
+  , free'
   , pure
   , impure
   , shape
   , position
+  , addTVars
     -- * reserved identifiers
   , reservedIdents
   )
@@ -46,6 +48,15 @@ imports = Agda.simpleImport $ Agda.qname [baseLibName] $ Agda.name "Free"
 free :: Agda.Name
 free = Agda.name "Free"
 
+free' :: Agda.Expr -> Agda.Expr
+free' e = foldl1
+  Agda.app
+  [ Agda.Ident (Agda.qname' free)
+  , Agda.Ident (Agda.qname' shape)
+  , Agda.Ident (Agda.qname' position)
+  , e
+  ]
+
 pureConName :: Agda.Name
 pureConName = Agda.name "pure"
 
@@ -63,6 +74,9 @@ shape = Agda.name "S"
 
 position :: Agda.Name
 position = Agda.name "P"
+
+addTVars :: [Agda.Name] -> [Agda.Name]
+addTVars ts = shape : position : ts
 
 -------------------------------------------------------------------------------
 -- Reserved identifiers                                                      --

--- a/src/lib/FreeC/Backend/Agda/Converter.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter.hs
@@ -1,3 +1,6 @@
+-- | This module exports functions for generating Agda that uses the @Free@
+--   monad from out intermediate representation.
+
 module FreeC.Backend.Agda.Converter
   ( convertModule
   , convertFuncDecl

--- a/src/lib/FreeC/Backend/Agda/Converter.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter.hs
@@ -1,0 +1,10 @@
+module FreeC.Backend.Agda.Converter
+  ( convertModule
+  , convertFuncDecl
+  )
+where
+
+import           FreeC.Backend.Agda.Converter.Module
+                                                ( convertModule )
+import           FreeC.Backend.Agda.Converter.FuncDecl
+                                                ( convertFuncDecl )

--- a/src/lib/FreeC/Backend/Agda/Converter.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter.hs
@@ -1,6 +1,10 @@
 module FreeC.Backend.Agda.Converter
   ( convertModule
   , convertFuncDecl
+  , convertType
+  , convertFunctionType
+  , convertConstructorType
+  , renameAgdaTypeVar
   )
 where
 
@@ -8,3 +12,9 @@ import           FreeC.Backend.Agda.Converter.Module
                                                 ( convertModule )
 import           FreeC.Backend.Agda.Converter.FuncDecl
                                                 ( convertFuncDecl )
+import           FreeC.Backend.Agda.Converter.Type
+                                                ( convertType
+                                                , convertFunctionType
+                                                , convertConstructorType
+                                                , renameAgdaTypeVar
+                                                )

--- a/src/lib/FreeC/Backend/Agda/Converter/Free.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter/Free.hs
@@ -1,0 +1,38 @@
+-- | This module contains auxilary functions that help to generate Coq code
+--   that uses the @Free@ monad.
+
+module FreeC.Backend.Agda.Converter.Free
+  ( generatePure
+  , free
+  , applyFreeArgs
+  , addFreeArgs
+  )
+where
+
+import qualified FreeC.Backend.Agda.Syntax     as Agda
+import qualified FreeC.Backend.Agda.Base       as Agda.Base
+
+-- | Applies the @pure@ constructor of the free monad to the given expression.
+generatePure :: Agda.Expr -> Agda.Expr
+generatePure =
+  Agda.app $ Agda.Ident $ Agda.qname [Agda.Base.baseLibName] Agda.Base.pure
+
+-- | Lifts a type in the free monad.
+free :: Agda.Expr -> Agda.Expr
+free = Agda.app $ applyFreeArgs $ Agda.qname' Agda.Base.free
+
+-- | Apply the @Shape@ and @Pos@ argument to the given type constructor.
+--
+-- > c ↦ c @S @P
+applyFreeArgs :: Agda.QName -> Agda.Expr
+applyFreeArgs qname = foldl1
+  Agda.app
+  [ Agda.Ident qname
+  , Agda.Ident (Agda.qname' Agda.Base.shape)
+  , Agda.Ident (Agda.qname' Agda.Base.position)
+  ]
+
+-- | Adds the resvered names for the free args @Shape@ and @Pos@ to a list of
+--   names.
+addFreeArgs :: [Agda.Name] -> [Agda.Name]
+addFreeArgs ts = Agda.Base.shape : Agda.Base.position : ts

--- a/src/lib/FreeC/Backend/Agda/Converter/Free.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter/Free.hs
@@ -23,7 +23,7 @@ free = Agda.app $ applyFreeArgs $ Agda.qname' Agda.Base.free
 
 -- | Apply the @Shape@ and @Pos@ argument to the given type constructor.
 --
--- > c ↦ c @S @P
+-- > c ↦ c Shape Pos
 applyFreeArgs :: Agda.QName -> Agda.Expr
 applyFreeArgs qname = foldl1
   Agda.app

--- a/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
@@ -1,6 +1,10 @@
 module FreeC.Backend.Agda.Converter.FuncDecl where
 
+import           Prelude                 hiding ( mod )
+
+import           Data.Function                  ( on )
 import           Data.List.Extra                ( snoc )
+import           Data.Maybe                     ( fromJust )
 
 import qualified FreeC.Backend.Agda.Syntax     as Agda
 import qualified FreeC.Backend.Agda.Base       as Agda.Base
@@ -9,20 +13,21 @@ import           FreeC.Monad.Converter          ( Converter
                                                 , inEnv
                                                 )
 import           FreeC.Environment              ( lookupAgdaIdent )
+import           Debug.Trace
 
 convertFuncDecl :: IR.FuncDecl -> Converter [Agda.Declaration]
 convertFuncDecl decl = sequence [convertSignature decl]
 
 convertSignature :: IR.FuncDecl -> Converter Agda.Declaration
 convertSignature (IR.FuncDecl _ ident tVars args retType _) =
-  Agda.funcSig <$> convertName ident <*> liftType tVars types
+  Agda.funcSig <$> convertIdent ident <*> liftType tVars types
   where types = (IR.varPatType <$> args) `snoc` retType
 
 convertDef :: IR.FuncDecl -> Converter Agda.Declaration
 convertDef = undefined
 
-convertName :: IR.DeclIdent -> Converter Agda.Name
-convertName ident = do
+convertIdent :: IR.DeclIdent -> Converter Agda.Name
+convertIdent ident = do
   let name = IR.declIdentName ident
   Just qualid <- inEnv $ lookupAgdaIdent IR.ValueScope name
   pure $ Agda.unqualify qualid
@@ -32,5 +37,33 @@ convertName ident = do
 -------------------------------------------------------------------------------
 
 liftType :: [IR.TypeVarDecl] -> [Maybe IR.Type] -> Converter Agda.Expr
-liftType _ _ =
-  pure $ Agda.pi [Agda.Base.shape, Agda.Base.position] $ Agda.intLiteral 42
+liftType tVars ts = Agda.pi tVars' <$> convertFunc (fromJust <$> ts)
+  where tVars' = Agda.Base.addTVars (Agda.name . IR.typeVarDeclIdent <$> tVars)
+
+-- | Lifts an n-ary function piece wise. Functions, which take all their
+--   arguments aren't evaluated until they are fully applied. Therefore partial
+--   application cannot produce @undefined@.
+--
+--   > (τ₁ → τ₂ → … → τₙ)* = τ₁' → τ₂' → … → τₙ'
+convertFunc :: [IR.Type] -> Converter Agda.Expr
+convertFunc ts =
+  foldr1 Agda.func <$> mapM (fmap Agda.Base.free' . convertType) ts
+
+convertType :: IR.Type -> Converter Agda.Expr
+convertType (IR.TypeVar _ name) = pure $ Agda.ident name -- TODO: lookup
+convertType (IR.TypeCon _ name) = convertConName name
+convertType (IR.TypeApp  _ l r) = Agda.app <$> convertType l <*> convertType r
+convertType (IR.FuncType _ l r) = freeFunc <$> convertType l <*> convertType r
+  where freeFunc = Agda.func `on` Agda.Base.free'
+
+convertConName :: IR.QName -> Converter Agda.Expr
+convertConName (IR.Qual _ n) = pure $ Agda.Ident $ Agda.qname' $ convertName n
+convertConName (IR.UnQual n) = pure $ Agda.Ident $ Agda.qname' $ convertName n
+
+convertName :: IR.Name -> Agda.Name
+convertName n = Agda.name $ case n of
+  IR.Ident  name -> name
+  IR.Symbol "[]" -> "List"
+  IR.Symbol ","  -> "Pair"
+  IR.Symbol name -> trace ("Missing ident: " <> name) undefined
+

--- a/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
@@ -35,7 +35,7 @@ convertFuncDecl decl = localEnv $ sequence [convertSignature decl]
 convertSignature :: IR.FuncDecl -> Converter Agda.Declaration
 convertSignature (IR.FuncDecl _ ident tVars args retType _) =
   Agda.funcSig <$> lookupValueIdent ident <*> convertFunc_ tVars types
-  where types = (map IR.varPatType args) `snoc` retType
+  where types = map IR.varPatType args `snoc` retType
 
 -- | Looks up the name of a Haskell function in the environment and converts it
 --   to an Agda name.

--- a/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
@@ -24,7 +24,6 @@ import           FreeC.Monad.Converter          ( Converter
                                                 , localEnv
                                                 )
 
-
 -- | Converts the given function declarations. Returns the declarations for the
 --   type signature and the definition (TODO).
 convertFuncDecl :: IR.FuncDecl -> Converter [Agda.Declaration]
@@ -48,5 +47,3 @@ convertFunc_ :: [IR.TypeVarDecl] -> [Maybe IR.Type] -> Converter Agda.Expr
 convertFunc_ tVars ts = Agda.pi <$> tVars' <*> convertFunctionType
   (map fromJust ts) -- handled in #19
   where tVars' = addFreeArgs <$> mapM renameAgdaTypeVar tVars
-
-

--- a/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
@@ -1,1 +1,8 @@
 module FreeC.Backend.Agda.Converter.FuncDecl where
+
+import qualified FreeC.Backend.Agda.Syntax     as Agda
+import qualified FreeC.IR.Syntax               as IR
+import           FreeC.Monad.Converter
+
+convertFuncDecl :: IR.FuncDecl -> Converter [Agda.Declaration]
+convertFuncDecl _ = pure []

--- a/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
@@ -35,7 +35,7 @@ convertFuncDecl decl = localEnv $ sequence [convertSignature decl]
 convertSignature :: IR.FuncDecl -> Converter Agda.Declaration
 convertSignature (IR.FuncDecl _ ident tVars args retType _) =
   Agda.funcSig <$> lookupValueIdent ident <*> convertFunc_ tVars types
-  where types = (IR.varPatType <$> args) `snoc` retType
+  where types = (IR.varPatType `map` args) `snoc` retType
 
 -- | Looks up the name of a Haskell function in the environment and converts it
 --   to an Agda name.
@@ -46,7 +46,7 @@ lookupValueIdent (IR.DeclIdent srcSpan name) =
 -- | Converts a fully applied function.
 convertFunc_ :: [IR.TypeVarDecl] -> [Maybe IR.Type] -> Converter Agda.Expr
 convertFunc_ tVars ts = Agda.pi <$> tVars' <*> convertFunctionType
-  (fromJust <$> ts) -- handled in #19
+  (fromJust `map` ts) -- handled in #19
   where tVars' = addFreeArgs <$> mapM renameAgdaTypeVar tVars
 
 

--- a/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
@@ -1,3 +1,6 @@
+-- | This module contains functions for generating Agda function declarations
+--   from our intermediate representation.
+
 module FreeC.Backend.Agda.Converter.FuncDecl
   ( convertFuncDecl
   )

--- a/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
@@ -2,7 +2,13 @@ module FreeC.Backend.Agda.Converter.FuncDecl where
 
 import qualified FreeC.Backend.Agda.Syntax     as Agda
 import qualified FreeC.IR.Syntax               as IR
-import           FreeC.Monad.Converter
+import           FreeC.Monad.Converter          ( Converter
+                                                , inEnv
+                                                )
+import           FreeC.Environment              ( lookupAgdaIdent )
 
 convertFuncDecl :: IR.FuncDecl -> Converter [Agda.Declaration]
-convertFuncDecl _ = pure []
+convertFuncDecl (IR.FuncDecl _ ident typeVar args retType expr) = do
+  let name = IR.declIdentName ident
+  Just qualid <- inEnv $ lookupAgdaIdent IR.ValueScope name
+  pure [Agda.funcSig (Agda.unqualify qualid) (Agda.intLiteral 42)]

--- a/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
@@ -35,7 +35,7 @@ convertFuncDecl decl = localEnv $ sequence [convertSignature decl]
 convertSignature :: IR.FuncDecl -> Converter Agda.Declaration
 convertSignature (IR.FuncDecl _ ident tVars args retType _) =
   Agda.funcSig <$> lookupValueIdent ident <*> convertFunc_ tVars types
-  where types = (IR.varPatType `map` args) `snoc` retType
+  where types = (map IR.varPatType args) `snoc` retType
 
 -- | Looks up the name of a Haskell function in the environment and converts it
 --   to an Agda name.
@@ -46,7 +46,7 @@ lookupValueIdent (IR.DeclIdent srcSpan name) =
 -- | Converts a fully applied function.
 convertFunc_ :: [IR.TypeVarDecl] -> [Maybe IR.Type] -> Converter Agda.Expr
 convertFunc_ tVars ts = Agda.pi <$> tVars' <*> convertFunctionType
-  (fromJust `map` ts) -- handled in #19
+  (map fromJust ts) -- handled in #19
   where tVars' = addFreeArgs <$> mapM renameAgdaTypeVar tVars
 
 

--- a/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
@@ -8,7 +8,8 @@ import           Prelude                 hiding ( mod )
 import           Data.List.Extra                ( snoc )
 import           Data.Maybe                     ( fromJust )
 
-import qualified FreeC.Backend.Agda.Base       as Agda.Base
+import           FreeC.Backend.Agda.Converter.Free
+                                                ( addFreeArgs )
 import           FreeC.Backend.Agda.Converter.Type
                                                 ( convertFunctionType
                                                 , renameAgdaTypeVar
@@ -43,5 +44,6 @@ lookupValueIdent (IR.DeclIdent srcSpan name) =
 convertFunc_ :: [IR.TypeVarDecl] -> [Maybe IR.Type] -> Converter Agda.Expr
 convertFunc_ tVars ts = Agda.pi <$> tVars' <*> convertFunctionType
   (fromJust <$> ts) -- handled in #19
-  where tVars' = Agda.Base.addTVars <$> mapM renameAgdaTypeVar tVars
+  where tVars' = addFreeArgs <$> mapM renameAgdaTypeVar tVars
+
 

--- a/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
@@ -3,23 +3,20 @@ module FreeC.Backend.Agda.Converter.FuncDecl
   )
 where
 
-import           Prelude                 hiding ( mod )
-
 import           Data.Function                  ( on )
 import           Data.List.Extra                ( snoc )
 import           Data.Maybe                     ( fromJust )
-
-import qualified FreeC.Backend.Agda.Syntax     as Agda
 import qualified FreeC.Backend.Agda.Base       as Agda.Base
+import qualified FreeC.Backend.Agda.Syntax     as Agda
+import           FreeC.Environment              ( lookupAgdaIdent )
+import           FreeC.Environment.LookupOrFail ( lookupAgdaIdentOrFail )
+import           FreeC.Environment.Renamer      ( renameAndDefineAgdaTypeVar )
 import qualified FreeC.IR.Syntax               as IR
 import           FreeC.Monad.Converter          ( Converter
                                                 , inEnv
                                                 , localEnv
                                                 )
-import           FreeC.Environment              ( lookupAgdaIdent )
-import           FreeC.Environment.Renamer      ( renameAndDefineAgdaTypeVar )
-import           FreeC.Environment.LookupOrFail ( lookupAgdaIdentOrFail )
-
+import           Prelude                 hiding ( mod )
 
 -- | Converts the given function declarations. Returns the declarations for the
 --   type signature and the definition (TODO).
@@ -77,4 +74,3 @@ convertType (IR.TypeCon s name) =
 convertType (IR.TypeApp  _ l r) = Agda.app <$> convertType l <*> convertType r
 convertType (IR.FuncType _ l r) = freeFunc <$> convertType l <*> convertType r
   where freeFunc = Agda.func `on` Agda.Base.free'
-

--- a/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
@@ -5,14 +5,16 @@ where
 
 import           Prelude                 hiding ( mod )
 
-import           Data.Function                  ( on )
 import           Data.List.Extra                ( snoc )
 import           Data.Maybe                     ( fromJust )
 
 import qualified FreeC.Backend.Agda.Base       as Agda.Base
+import           FreeC.Backend.Agda.Converter.Type
+                                                ( convertFunctionType
+                                                , renameAgdaTypeVar
+                                                )
 import qualified FreeC.Backend.Agda.Syntax     as Agda
 import           FreeC.Environment.LookupOrFail ( lookupAgdaIdentOrFail )
-import           FreeC.Environment.Renamer      ( renameAndDefineAgdaTypeVar )
 import qualified FreeC.IR.Syntax               as IR
 import           FreeC.Monad.Converter          ( Converter
                                                 , localEnv
@@ -37,39 +39,9 @@ lookupValueIdent :: IR.DeclIdent -> Converter Agda.Name
 lookupValueIdent (IR.DeclIdent srcSpan name) =
   Agda.unqualify <$> lookupAgdaIdentOrFail srcSpan IR.ValueScope name
 
--------------------------------------------------------------------------------
--- Free Type Lifting                                                         --
--------------------------------------------------------------------------------
-
 -- | Converts a fully applied function.
 convertFunc_ :: [IR.TypeVarDecl] -> [Maybe IR.Type] -> Converter Agda.Expr
-convertFunc_ tVars ts = Agda.pi <$> tVars' <*> convertFunc (fromJust <$> ts)
+convertFunc_ tVars ts = Agda.pi <$> tVars' <*> convertFunctionType
+  (fromJust <$> ts) -- handled in #19
   where tVars' = Agda.Base.addTVars <$> mapM renameAgdaTypeVar tVars
 
-renameAgdaTypeVar :: IR.TypeVarDecl -> Converter Agda.Name
-renameAgdaTypeVar (IR.TypeVarDecl srcSpan name) =
-  Agda.unqualify <$> renameAndDefineAgdaTypeVar srcSpan name
-
--- | Lifts an n-ary function piece wise. Functions, which take all their
---   arguments aren't evaluated until they are fully applied. Therefore partial
---   application cannot produce @undefined@.
---
---   > (τ₁ → τ₂ → … → τₙ)* = τ₁' → τ₂' → … → τₙ'
-convertFunc :: [IR.Type] -> Converter Agda.Expr
-convertFunc ts =
-  foldr1 Agda.func <$> mapM (fmap Agda.Base.free' . convertType) ts
-
--- | Implements the dagger translation. Types are lifted recursively in the free
---   monad.
---   The dagger translation is denoted by ' and ^ denotes renamed identifiers.
---
---   > (τ → σ)’ = Free (Free τ’ → Free σ’)
---   > α' = α    (τ σ)’ = τ’ σ’    C' = Ĉ @S @P
-convertType :: IR.Type -> Converter Agda.Expr
-convertType (IR.TypeVar s name) = Agda.Ident
-  <$> lookupAgdaIdentOrFail s IR.TypeScope (IR.UnQual (IR.Ident name))
-convertType (IR.TypeCon s name) =
-  Agda.Base.freeArgs <$> lookupAgdaIdentOrFail s IR.TypeScope name
-convertType (IR.TypeApp  _ l r) = Agda.app <$> convertType l <*> convertType r
-convertType (IR.FuncType _ l r) = freeFunc <$> convertType l <*> convertType r
-  where freeFunc = Agda.func `on` Agda.Base.free'

--- a/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
@@ -17,8 +17,7 @@ import           FreeC.Monad.Converter          ( Converter
                                                 , localEnv
                                                 )
 import           FreeC.Environment              ( lookupAgdaIdent )
-import           FreeC.Environment.Renamer      ( renameAndDefineAgdaTypeVar
-                                                )
+import           FreeC.Environment.Renamer      ( renameAndDefineAgdaTypeVar )
 import           FreeC.Environment.LookupOrFail ( lookupAgdaIdentOrFail )
 
 

--- a/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
@@ -1,6 +1,9 @@
 module FreeC.Backend.Agda.Converter.FuncDecl where
 
+import           Data.List.Extra                ( snoc )
+
 import qualified FreeC.Backend.Agda.Syntax     as Agda
+import qualified FreeC.Backend.Agda.Base       as Agda.Base
 import qualified FreeC.IR.Syntax               as IR
 import           FreeC.Monad.Converter          ( Converter
                                                 , inEnv
@@ -8,7 +11,26 @@ import           FreeC.Monad.Converter          ( Converter
 import           FreeC.Environment              ( lookupAgdaIdent )
 
 convertFuncDecl :: IR.FuncDecl -> Converter [Agda.Declaration]
-convertFuncDecl (IR.FuncDecl _ ident typeVar args retType expr) = do
+convertFuncDecl decl = sequence [convertSignature decl]
+
+convertSignature :: IR.FuncDecl -> Converter Agda.Declaration
+convertSignature (IR.FuncDecl _ ident tVars args retType _) =
+  Agda.funcSig <$> convertName ident <*> liftType tVars types
+  where types = (IR.varPatType <$> args) `snoc` retType
+
+convertDef :: IR.FuncDecl -> Converter Agda.Declaration
+convertDef = undefined
+
+convertName :: IR.DeclIdent -> Converter Agda.Name
+convertName ident = do
   let name = IR.declIdentName ident
   Just qualid <- inEnv $ lookupAgdaIdent IR.ValueScope name
-  pure [Agda.funcSig (Agda.unqualify qualid) (Agda.intLiteral 42)]
+  pure $ Agda.unqualify qualid
+
+-------------------------------------------------------------------------------
+-- Free Type Lifting                                                         --
+-------------------------------------------------------------------------------
+
+liftType :: [IR.TypeVarDecl] -> [Maybe IR.Type] -> Converter Agda.Expr
+liftType _ _ =
+  pure $ Agda.pi [Agda.Base.shape, Agda.Base.position] $ Agda.intLiteral 42

--- a/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
@@ -3,9 +3,12 @@ module FreeC.Backend.Agda.Converter.FuncDecl
   )
 where
 
+import           Prelude                 hiding ( mod )
+
 import           Data.Function                  ( on )
 import           Data.List.Extra                ( snoc )
 import           Data.Maybe                     ( fromJust )
+
 import qualified FreeC.Backend.Agda.Base       as Agda.Base
 import qualified FreeC.Backend.Agda.Syntax     as Agda
 import           FreeC.Environment.LookupOrFail ( lookupAgdaIdentOrFail )
@@ -14,7 +17,7 @@ import qualified FreeC.IR.Syntax               as IR
 import           FreeC.Monad.Converter          ( Converter
                                                 , localEnv
                                                 )
-import           Prelude                 hiding ( mod )
+
 
 -- | Converts the given function declarations. Returns the declarations for the
 --   type signature and the definition (TODO).

--- a/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter/FuncDecl.hs
@@ -1,0 +1,1 @@
+module FreeC.Backend.Agda.Converter.FuncDecl where

--- a/src/lib/FreeC/Backend/Agda/Converter/Module.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter/Module.hs
@@ -1,7 +1,11 @@
 module FreeC.Backend.Agda.Converter.Module where
 
 import           Control.Monad                  ( (>=>) )
+import           Control.Monad.Extra            ( concatMapM )
 
+import           Data.List.Extra                ( splitOn )
+
+import           FreeC.Backend.Agda.Converter.FuncDecl
 import qualified FreeC.Backend.Agda.Syntax     as Agda
 import qualified FreeC.IR.Syntax               as IR
 import           FreeC.Monad.Converter
@@ -9,9 +13,14 @@ import           FreeC.Pipeline
 
 
 -- | Converts a Haskell module to an Agda declaration.
-convertModule :: IR.Module -> Converter [Agda.Declaration]
+convertModule :: IR.Module -> Converter Agda.Declaration
 convertModule = moduleEnv . (runPipeline >=> convertModule')
 
 -- | Like 'convertModule'' but does not apply any compiler passes beforehand.
-convertModule' :: IR.Module -> Converter [Agda.Declaration]
-convertModule' _ = undefined
+convertModule' :: IR.Module -> Converter Agda.Declaration
+convertModule' (IR.Module _ name _ _ _ _ funcDecls) =
+  Agda.moduleDecl (convertModName name) <$> concatMapM convertFuncDecl funcDecls
+
+convertModName :: IR.ModName -> Agda.QName
+convertModName name = Agda.qname (init parts) (last parts)
+  where parts = Agda.name <$> splitOn "." name

--- a/src/lib/FreeC/Backend/Agda/Converter/Module.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter/Module.hs
@@ -1,0 +1,17 @@
+module FreeC.Backend.Agda.Converter.Module where
+
+import           Control.Monad                  ( (>=>) )
+
+import qualified FreeC.Backend.Agda.Syntax     as Agda
+import qualified FreeC.IR.Syntax               as IR
+import           FreeC.Monad.Converter
+import           FreeC.Pipeline
+
+
+-- | Converts a Haskell module to an Agda declaration.
+convertModule :: IR.Module -> Converter [Agda.Declaration]
+convertModule = moduleEnv . (runPipeline >=> convertModule')
+
+-- | Like 'convertModule'' but does not apply any compiler passes beforehand.
+convertModule' :: IR.Module -> Converter [Agda.Declaration]
+convertModule' _ = undefined

--- a/src/lib/FreeC/Backend/Agda/Converter/Module.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter/Module.hs
@@ -13,7 +13,6 @@ import qualified FreeC.IR.Syntax               as IR
 import           FreeC.Monad.Converter
 import           FreeC.Pipeline
 
-
 -- | Converts a Haskell module to an Agda declaration.
 convertModule :: IR.Module -> Converter Agda.Declaration
 convertModule = moduleEnv . (runPipeline >=> convertModule')

--- a/src/lib/FreeC/Backend/Agda/Converter/Module.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter/Module.hs
@@ -1,3 +1,5 @@
+-- | This module contains functions for converting Haskell modules to Agda.
+
 module FreeC.Backend.Agda.Converter.Module where
 
 import           Control.Monad                  ( (>=>) )
@@ -21,6 +23,7 @@ convertModule' :: IR.Module -> Converter Agda.Declaration
 convertModule' (IR.Module _ name _ _ _ _ funcDecls) =
   Agda.moduleDecl (convertModName name) <$> concatMapM convertFuncDecl funcDecls
 
+-- | Converts a Haskell module name to an Agda module name
 convertModName :: IR.ModName -> Agda.QName
 convertModName name = Agda.qname (init parts) (last parts)
   where parts = Agda.name <$> splitOn "." name

--- a/src/lib/FreeC/Backend/Agda/Converter/Type.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter/Type.hs
@@ -10,8 +10,6 @@ module FreeC.Backend.Agda.Converter.Type
   )
 where
 
-import           Control.Monad                  ( mapM )
-
 import qualified FreeC.Backend.Agda.Syntax     as Agda
 import           FreeC.Backend.Agda.Converter.Free
                                                 ( free
@@ -64,12 +62,17 @@ renameAgdaTypeVar (IR.TypeVarDecl srcSpan name) =
 dagger :: IR.Type -> Converter Agda.Expr
 dagger = fmap free . star
 
--- | The star translation for monotypes as described by Abel et al.
+-- | Lifts a type from IR to Agda by renaming type variables and constructors,
+--   adding the free arguments to constructors and lifting function types in
+--   the @Free@ monad.
 --
--- > (τ₁ τ₂)* = τ₁* τ₂*
--- > (τ₁ → τ₂)* = τ₁' → τ₂'
--- > C* = Ĉ Shape Position
--- > α* = α̂
+--   This corresponds to the star translation for monotypes as described by
+--   Abel et al.
+--
+--   > (τ₁ τ₂)* = τ₁* τ₂*
+--   > (τ₁ → τ₂)* = τ₁' → τ₂'
+--   > C* = Ĉ Shape Position
+--   > α* = α̂
 star :: IR.Type -> Converter Agda.Expr
 star (IR.TypeVar s name) = Agda.Ident
   <$> lookupAgdaIdentOrFail s IR.TypeScope (IR.UnQual (IR.Ident name))

--- a/src/lib/FreeC/Backend/Agda/Converter/Type.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter/Type.hs
@@ -75,6 +75,4 @@ star (IR.TypeVar s name) = Agda.Ident
 star (IR.TypeCon s name) =
   applyFreeArgs <$> lookupAgdaIdentOrFail s IR.TypeScope name
 star (IR.TypeApp  _ l r) = Agda.app <$> star l <*> star r
--- At the moment this case simplifies to
--- @Agda.func <$> free (dagger l) <*> free (dagger r)@.
 star (IR.FuncType _ l r) = Agda.fun <$> dagger l <*> dagger r

--- a/src/lib/FreeC/Backend/Agda/Converter/Type.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter/Type.hs
@@ -1,0 +1,83 @@
+module FreeC.Backend.Agda.Converter.Type
+  ( convertType
+  , convertFunctionType
+  , convertConstructorType
+  , renameAgdaTypeVar
+  )
+where
+
+-- | Implements the IR to Agda translation, which applies the monadic lifting as
+--   described by Abel et al. in "Verifying Haskell Programs Using Constructive
+--   Type Theory".
+
+import           Control.Monad                  ( mapM )
+
+import qualified FreeC.Backend.Agda.Base       as Agda.Base
+import qualified FreeC.Backend.Agda.Syntax     as Agda
+import           FreeC.Environment.LookupOrFail ( lookupAgdaIdentOrFail )
+import           FreeC.Environment.Renamer      ( renameAndDefineAgdaTypeVar )
+import qualified FreeC.IR.Syntax               as IR
+import           FreeC.Monad.Converter          ( Converter )
+
+-- | Lifts a single type.
+convertType :: IR.Type -> Converter Agda.Expr
+convertType = dagger
+
+-- | Functions not defined in terms lambdas (@f x = …@ not @f = \x -> …@) aren't
+--   evaluated until fully applied, i.e. cannot be bottom. Therefore interleaving
+--   monadic layers isn't needed.
+--
+--   > (τ₁ → τ₂ → … → τₙ)' = τ₁' → Free τ₂' → … → Free τₙ'
+convertFunctionType :: [IR.Type] -> Converter Agda.Expr
+convertFunctionType types = foldr1 Agda.fun <$> mapM dagger types
+
+-- | Constructors aren't evaluated until fully applied. Furthermore the return
+--   type of a constructor for a data type D has to be D and therefore cannot be
+--   lifted.
+--
+--   > (τ₁ → τ₂ → … → τₙ → D)' = τ₁' → Free τ₂' → … → τₙ' → D
+convertConstructorType :: [IR.Type] -> Converter Agda.Expr
+convertConstructorType types =
+  -- We can use the @star@ translation for the data type, because only the name
+  -- and the application of type and @Size@ variables have to be translated.
+  Agda.fun <$> convertFunctionType (init types) <*> star (last types)
+
+-- | Utility function for introducing a new Agda type variable to the current
+--   scope.
+renameAgdaTypeVar :: IR.TypeVarDecl -> Converter Agda.Name
+renameAgdaTypeVar (IR.TypeVarDecl srcSpan name) =
+  Agda.unqualify <$> renameAndDefineAgdaTypeVar srcSpan name
+-------------------------------------------------------------------------------
+-- Translations                                                              --
+-------------------------------------------------------------------------------
+
+-- | The dagger translation as describer by Abel et al.
+--   Normally the dagger translations separates mono and poly types, but the
+--   polytype cases are not applicable for our IR.
+--   Note: If polytypes are added in the future (e.g. for type classes) add
+--   their type translation here.
+--
+--   > -- not applicable (polytypes)
+--   > (∀α:κ.σ)’ = (α : κ’) → σ’ -- RankNTypes translate to pi types
+--   > (σ ↦ τ)’ = σ’ → τ’        -- functions handling polytypes e.g.
+--   >                           -- result from type class dictionary translation
+--   > -- all other cases (monotypes):
+--   > τ’ = m τ
+dagger :: IR.Type -> Converter Agda.Expr
+dagger = fmap Agda.Base.free' . star
+
+-- | The star translation for monotypes as described by Abel et al.
+--
+-- > (σ τ)* = σ* τ*
+-- > (σ → τ)* = σ’ → τ’
+-- > C* = Ĉ @S @P
+-- > α* = α
+star :: IR.Type -> Converter Agda.Expr
+star (IR.TypeVar s name) = Agda.Ident
+  <$> lookupAgdaIdentOrFail s IR.TypeScope (IR.UnQual (IR.Ident name))
+star (IR.TypeCon s name) =
+  Agda.Base.freeArgs <$> lookupAgdaIdentOrFail s IR.TypeScope name
+star (IR.TypeApp  _ l r) = Agda.app <$> star l <*> star r
+-- At the moment this case simplifies to
+-- @Agda.func <$> Agda.base.free' (dagger l) <*> Agda.base.free' (dagger r)@.
+star (IR.FuncType _ l r) = Agda.fun <$> dagger l <*> dagger r

--- a/src/lib/FreeC/Backend/Agda/Converter/Type.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter/Type.hs
@@ -38,7 +38,7 @@ convertFunctionType types = foldr1 Agda.fun <$> mapM dagger types
 --   type of a constructor for a data type D has to be D and therefore cannot be
 --   lifted.
 --
---   > (τ₁ -> … -> τₙ -> ρ)' = τ₁' → … → τₙ' → ρ*
+--   > τ₁ -> … -> τₙ -> ρ ↦ τ₁' → … → τₙ' → ρ*
 convertConstructorType :: [IR.Type] -> Converter Agda.Expr
 convertConstructorType types =
   -- We can use the @star@ translation for the data type, because only the name
@@ -55,7 +55,9 @@ renameAgdaTypeVar (IR.TypeVarDecl srcSpan name) =
 -- Translations                                                              --
 -------------------------------------------------------------------------------
 
--- | The dagger translation as describer by Abel et al.
+-- | Converts a type from IR to Agda by lifting it into the @Free@ monad.
+--   This corresponds to the dagger translation for monotypes as described by 
+--   Abel et al.
 --
 --   > τ' = Free τ
 dagger :: IR.Type -> Converter Agda.Expr

--- a/src/lib/FreeC/Backend/Agda/Converter/Type.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter/Type.hs
@@ -59,7 +59,7 @@ renameAgdaTypeVar (IR.TypeVarDecl srcSpan name) =
 --   This corresponds to the dagger translation for monotypes as described by 
 --   Abel et al.
 --
---   > τ' = Free τ
+--   > τ' = Free τ*
 dagger :: IR.Type -> Converter Agda.Expr
 dagger = fmap free . star
 

--- a/src/lib/FreeC/Backend/Agda/Converter/Type.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter/Type.hs
@@ -56,7 +56,8 @@ renameAgdaTypeVar (IR.TypeVarDecl srcSpan name) =
 -------------------------------------------------------------------------------
 
 -- | Converts a type from IR to Agda by lifting it into the @Free@ monad.
---   This corresponds to the dagger translation for monotypes as described by 
+--
+--   This corresponds to the dagger translation for monotypes as described by
 --   Abel et al.
 --
 --   > τ' = Free τ*

--- a/src/lib/FreeC/Backend/Agda/Converter/Type.hs
+++ b/src/lib/FreeC/Backend/Agda/Converter/Type.hs
@@ -29,19 +29,20 @@ convertType = dagger
 --   monadic layers isn't needed.
 --
 --   > τ₁ -> … -> τₙ -> ρ ↦ τ₁' → … → τₙ' → ρ'
-convertFunctionType :: [IR.Type] -> Converter Agda.Expr
-convertFunctionType types = foldr1 Agda.fun <$> mapM dagger types
+convertFunctionType :: [IR.Type] -> IR.Type -> Converter Agda.Expr
+convertFunctionType argTypes returnType =
+  foldr Agda.fun <$> dagger returnType <*> mapM dagger argTypes
 
 -- | Constructors aren't evaluated until fully applied. Furthermore the return
 --   type of a constructor for a data type D has to be D and therefore cannot be
 --   lifted.
 --
 --   > τ₁ -> … -> τₙ -> ρ ↦ τ₁' → … → τₙ' → ρ*
-convertConstructorType :: [IR.Type] -> Converter Agda.Expr
-convertConstructorType types =
+convertConstructorType :: [IR.Type] -> IR.Type -> Converter Agda.Expr
+convertConstructorType argTypes returnType =
   -- We can use the @star@ translation for the data type, because only the name
   -- and the application of type and @Size@ variables have to be translated.
-  Agda.fun <$> convertFunctionType (init types) <*> star (last types)
+  foldr Agda.fun <$> star returnType <*> mapM dagger argTypes
 
 -- | Utility function for introducing a new Agda type variable to the current
 --   scope.

--- a/src/lib/FreeC/Backend/Agda/Syntax.hs
+++ b/src/lib/FreeC/Backend/Agda/Syntax.hs
@@ -32,13 +32,6 @@ import           Agda.Syntax.Concrete
 import           Agda.Syntax.Literal
 import           Agda.Syntax.Position
 
-hiddenArgInfo :: ArgInfo
-hiddenArgInfo = ArgInfo { argInfoHiding        = Hidden
-                        , argInfoModality      = defaultModality
-                        , argInfoOrigin        = UserWritten
-                        , argInfoFreeVariables = UnknownFVs
-                        }
-
 -------------------------------------------------------------------------------
 -- Identifiers                                                               --
 -------------------------------------------------------------------------------
@@ -75,9 +68,13 @@ simpleImport modName = Import
 -- Declarations                                                              --
 -------------------------------------------------------------------------------
 
+-- | Smart constructor for creating a module containing a list of declarations.
 moduleDecl :: QName -> [Declaration] -> Declaration
 moduleDecl modName = Module NoRange modName []
 
+-- | Smart constructor for creating function type declarations.
+--
+--   > funcSig foo expr = foo : expr
 funcSig :: Name -> Expr -> Declaration
 funcSig = TypeSig defaultArgInfo Nothing
 
@@ -104,9 +101,11 @@ app l r@(App _ _ _) = App NoRange l $ defaultNamedArg $ paren r -- ($) is left a
 app l r@(Fun _ _ _) = App NoRange l $ defaultNamedArg $ paren r -- ($) bind stronger than (->)
 app l r             = App NoRange l $ defaultNamedArg r
 
+-- | Wraps the given expression in parenthesis.
 paren :: Expr -> Expr
 paren = Paren NoRange
 
+-- | Helper function for creating expressions from @String@s.
 ident :: String -> Expr
 ident = Ident . qname' . name
 
@@ -114,13 +113,25 @@ ident = Ident . qname' . name
 -- Types                                                                     --
 -------------------------------------------------------------------------------
 
--- | Function type
+-- | A smart constructor for non dependent function types.
 func :: Expr -> Expr -> Expr
 func l@(Fun _ _ _) = Fun NoRange (defaultArg (paren l)) -- (->) is right assoc.
 func l             = Fun NoRange (defaultArg l)
 
+-- | Creates a pi type binding the given names as hidden variables.
+--
+--   > pi [α, β, γ, …] expr = ∀ {α} {β} {γ} … → expr
 pi :: [Name] -> Expr -> Expr
 pi decls = Pi [TBind NoRange (bName <$> decls) (Underscore NoRange Nothing)]
 
+-- | Helper function for creating bound, named arguments.
 bName :: Name -> NamedArg Binder
 bName n = Arg hiddenArgInfo $ Named Nothing $ Binder Nothing $ mkBoundName_ n
+
+-- | Argument meta data marking them as hidden.
+hiddenArgInfo :: ArgInfo
+hiddenArgInfo = ArgInfo { argInfoHiding        = Hidden
+                        , argInfoModality      = defaultModality
+                        , argInfoOrigin        = UserWritten
+                        , argInfoFreeVariables = UnknownFVs
+                        }

--- a/src/lib/FreeC/Backend/Agda/Syntax.hs
+++ b/src/lib/FreeC/Backend/Agda/Syntax.hs
@@ -21,7 +21,7 @@ module FreeC.Backend.Agda.Syntax
   , app
   , ident
     -- * Types
-  , func
+  , fun
   , pi
   )
 where
@@ -130,9 +130,9 @@ ident = Ident . qname' . name
 -------------------------------------------------------------------------------
 
 -- | A smart constructor for non dependent function types.
-func :: Expr -> Expr -> Expr
-func l@(Fun _ _ _) = Fun NoRange (defaultArg (paren l)) -- (->) is right assoc.
-func l             = Fun NoRange (defaultArg l)
+fun :: Expr -> Expr -> Expr
+fun l@(Fun _ _ _) = Fun NoRange (defaultArg (paren l)) -- (->) is right assoc.
+fun l             = Fun NoRange (defaultArg l)
 
 -- | Creates a pi type binding the given names as hidden variables.
 --

--- a/src/lib/FreeC/Backend/Agda/Syntax.hs
+++ b/src/lib/FreeC/Backend/Agda/Syntax.hs
@@ -9,6 +9,7 @@ module FreeC.Backend.Agda.Syntax
   , name
   , qname
   , qname'
+  , nextQName
     -- * Imports
   , simpleImport
     -- * Declarations
@@ -48,6 +49,10 @@ qname modules n = foldr Qual (QName n) modules
 -- | Creates a qualified name using an empty list of module names.
 qname' :: Name -> QName
 qname' = qname []
+
+nextQName :: QName -> QName
+nextQName (Qual n qn) = Qual (nextName n) qn
+nextQName (QName n  ) = QName $ nextName n
 
 -------------------------------------------------------------------------------
 -- Imports                                                                   --

--- a/src/lib/FreeC/Backend/Agda/Syntax.hs
+++ b/src/lib/FreeC/Backend/Agda/Syntax.hs
@@ -9,7 +9,6 @@ module FreeC.Backend.Agda.Syntax
   , name
   , qname
   , qname'
-  , nextQName
     -- * Imports
   , simpleImport
     -- * Declarations
@@ -51,11 +50,6 @@ qname modules unQName = foldr Qual (QName unQName) modules
 -- | Creates a qualified name using an empty list of module names.
 qname' :: Name -> QName
 qname' = qname []
-
--- | Creates a new qualified name, by appending a number or incrementing it.
-nextQName :: QName -> QName
-nextQName (Qual modName qName) = Qual modName $ nextQName qName
-nextQName (QName unQName     ) = QName $ nextName unQName
 
 -------------------------------------------------------------------------------
 -- Imports                                                                   --

--- a/src/lib/FreeC/Backend/Agda/Syntax.hs
+++ b/src/lib/FreeC/Backend/Agda/Syntax.hs
@@ -18,6 +18,7 @@ module FreeC.Backend.Agda.Syntax
   , intLiteral
   , lambda
   , app
+  , ident
     -- * Types
   , func
   , pi
@@ -99,10 +100,15 @@ lambda args = Lam NoRange (DomainFree . defaultNamedArg . mkBinder_ <$> args)
 --
 --   @e a@
 app :: Expr -> Expr -> Expr
-app l r = App NoRange l $ defaultNamedArg r
+app l r@(App _ _ _) = App NoRange l $ defaultNamedArg $ paren r -- ($) is left assoc
+app l r@(Fun _ _ _) = App NoRange l $ defaultNamedArg $ paren r -- ($) bind stronger than (->)
+app l r             = App NoRange l $ defaultNamedArg r
 
 paren :: Expr -> Expr
 paren = Paren NoRange
+
+ident :: String -> Expr
+ident = Ident . qname' . name
 
 -------------------------------------------------------------------------------
 -- Types                                                                     --

--- a/src/lib/FreeC/Backend/Agda/Syntax.hs
+++ b/src/lib/FreeC/Backend/Agda/Syntax.hs
@@ -132,11 +132,13 @@ fun l             = Fun NoRange (defaultArg l)
 --
 --   > pi [α₁, …, αₙ] expr ↦ ∀ {α₁} … {αₙ} → expr
 pi :: [Name] -> Expr -> Expr
-pi decls = Pi [TBind NoRange (bName <$> decls) (Underscore NoRange Nothing)]
+pi decls =
+  Pi [TBind NoRange (hiddenArg <$> decls) (Underscore NoRange Nothing)]
 
--- | Helper function for creating bound, named arguments.
-bName :: Name -> NamedArg Binder
-bName n = Arg hiddenArgInfo $ Named Nothing $ Binder Nothing $ mkBoundName_ n
+-- | Helper function for creating hidden named arguments.
+hiddenArg :: Name -> NamedArg Binder
+hiddenArg n =
+  Arg hiddenArgInfo $ Named Nothing $ Binder Nothing $ mkBoundName_ n
 
 -- | Argument meta data marking them as hidden.
 hiddenArgInfo :: ArgInfo

--- a/src/lib/FreeC/Backend/Agda/Syntax.hs
+++ b/src/lib/FreeC/Backend/Agda/Syntax.hs
@@ -11,6 +11,7 @@ module FreeC.Backend.Agda.Syntax
   , qname'
     -- * Imports
   , simpleImport
+  , moduleDecl
     -- * Expressions
   , intLiteral
   , lambda
@@ -54,6 +55,9 @@ simpleImport modName = Import
   Nothing
   DoOpen
   (ImportDirective NoRange UseEverything [] [] Nothing)
+
+moduleDecl :: QName -> [Declaration] -> Declaration
+moduleDecl modName = Module NoRange modName []
 
 -------------------------------------------------------------------------------
 -- Expressions                                                               --

--- a/src/lib/FreeC/Backend/Agda/Syntax.hs
+++ b/src/lib/FreeC/Backend/Agda/Syntax.hs
@@ -11,7 +11,9 @@ module FreeC.Backend.Agda.Syntax
   , qname'
     -- * Imports
   , simpleImport
+    -- * Declarations
   , moduleDecl
+  , funcSig
     -- * Expressions
   , intLiteral
   , lambda
@@ -56,8 +58,15 @@ simpleImport modName = Import
   DoOpen
   (ImportDirective NoRange UseEverything [] [] Nothing)
 
+-------------------------------------------------------------------------------
+-- Declarations                                                              --
+-------------------------------------------------------------------------------
+
 moduleDecl :: QName -> [Declaration] -> Declaration
 moduleDecl modName = Module NoRange modName []
+
+funcSig :: Name -> Expr -> Declaration
+funcSig = TypeSig defaultArgInfo Nothing
 
 -------------------------------------------------------------------------------
 -- Expressions                                                               --

--- a/src/lib/FreeC/Backend/Agda/Syntax.hs
+++ b/src/lib/FreeC/Backend/Agda/Syntax.hs
@@ -130,7 +130,7 @@ fun l             = Fun NoRange (defaultArg l)
 
 -- | Creates a pi type binding the given names as hidden variables.
 --
---   > pi [α, β, γ, …] expr = ∀ {α} {β} {γ} … → expr
+--   > pi [α₁, …, αₙ] expr ↦ ∀ {α₁} … {αₙ} → expr
 pi :: [Name] -> Expr -> Expr
 pi decls = Pi [TBind NoRange (bName <$> decls) (Underscore NoRange Nothing)]
 

--- a/src/lib/FreeC/Backend/Agda/Syntax.hs
+++ b/src/lib/FreeC/Backend/Agda/Syntax.hs
@@ -33,6 +33,8 @@ import           Agda.Syntax.Concrete
 import           Agda.Syntax.Literal
 import           Agda.Syntax.Position
 
+import           FreeC.Util.Predicate           ( (.||.) )
+
 -------------------------------------------------------------------------------
 -- Identifiers                                                               --
 -------------------------------------------------------------------------------
@@ -88,6 +90,13 @@ funcSig = TypeSig defaultArgInfo Nothing
 -- Expressions                                                               --
 -------------------------------------------------------------------------------
 
+isApp :: Expr -> Bool
+isApp (App _ _ _) = True
+isApp _           = False
+
+isFun :: Expr -> Bool
+isFun (Fun _ _ _) = True
+isFun _           = False
 -- | Creates an integer literal.
 intLiteral :: Integer -> Expr
 intLiteral = Lit . LitNat NoRange
@@ -105,9 +114,8 @@ lambda args = Lam NoRange (DomainFree . defaultNamedArg . mkBinder_ <$> args)
 --
 --   > e a
 app :: Expr -> Expr -> Expr
-app l r@(App _ _ _) = App NoRange l $ defaultNamedArg $ paren r
-app l r@(Fun _ _ _) = App NoRange l $ defaultNamedArg $ paren r
-app l r             = App NoRange l $ defaultNamedArg r
+app l r =
+  App NoRange l $ defaultNamedArg (if isApp .||. isFun $ r then paren r else r)
 
 -- | Wraps the given expression in parenthesis.
 paren :: Expr -> Expr

--- a/src/lib/FreeC/Backend/Agda/Syntax.hs
+++ b/src/lib/FreeC/Backend/Agda/Syntax.hs
@@ -44,15 +44,16 @@ name str = Name NoRange InScope [Id str]
 -- | Create a qualified identifier given a local identifier as 'Name' and a
 --   list of module 'Name's.
 qname :: [Name] -> Name -> QName
-qname modules n = foldr Qual (QName n) modules
+qname modules unQName = foldr Qual (QName unQName) modules
 
 -- | Creates a qualified name using an empty list of module names.
 qname' :: Name -> QName
 qname' = qname []
 
+-- | Creates a new qualified name, by appending a number or incrementing it.
 nextQName :: QName -> QName
-nextQName (Qual n qn) = Qual (nextName n) qn
-nextQName (QName n  ) = QName $ nextName n
+nextQName (Qual modName qName) = Qual modName $ nextQName qName
+nextQName (QName unQName     ) = QName $ nextName unQName
 
 -------------------------------------------------------------------------------
 -- Imports                                                                   --

--- a/src/lib/FreeC/Backend/Agda/Syntax.hs
+++ b/src/lib/FreeC/Backend/Agda/Syntax.hs
@@ -38,12 +38,12 @@ import           Agda.Syntax.Position
 
 -- | Creates a (not qualified) Agda variable name from a 'String'.
 name :: String -> Name
-name ident = Name NoRange InScope [Id ident]
+name str = Name NoRange InScope [Id str]
 
 -- | Create a qualified identifier given a local identifier as 'Name' and a
 --   list of module 'Name's.
 qname :: [Name] -> Name -> QName
-qname modules ident = foldr Qual (QName ident) modules
+qname modules n = foldr Qual (QName n) modules
 
 -- | Creates a qualified name using an empty list of module names.
 qname' :: Name -> QName
@@ -93,12 +93,14 @@ intLiteral = Lit . LitNat NoRange
 lambda :: [Name] -> Expr -> Expr
 lambda args = Lam NoRange (DomainFree . defaultNamedArg . mkBinder_ <$> args)
 
--- | Creates an application AST node.
+-- | Creates an application AST node. Application is left associative and in
+--   in type expressions binds stronger than type arrow. For these cases paren-
+--   thesis are added automatically.
 --
---   @e a@
+--   > e a
 app :: Expr -> Expr -> Expr
-app l r@(App _ _ _) = App NoRange l $ defaultNamedArg $ paren r -- ($) is left assoc
-app l r@(Fun _ _ _) = App NoRange l $ defaultNamedArg $ paren r -- ($) bind stronger than (->)
+app l r@(App _ _ _) = App NoRange l $ defaultNamedArg $ paren r
+app l r@(Fun _ _ _) = App NoRange l $ defaultNamedArg $ paren r
 app l r             = App NoRange l $ defaultNamedArg r
 
 -- | Wraps the given expression in parenthesis.

--- a/src/lib/FreeC/Backend/Coq/Converter/Free.hs
+++ b/src/lib/FreeC/Backend/Coq/Converter/Free.hs
@@ -25,7 +25,7 @@ genericArgDecls explicitness =
   map (uncurry (Coq.typedBinder' explicitness)) Coq.Base.freeArgs
 
 -- | @Variable@ sentences for the parameters of the @Free@ monad.
---   
+--
 --   @Variable Shape : Type.@ and @Variable Pos : Shape -> Type.@
 genericArgVariables :: [Coq.Sentence]
 genericArgVariables = map (uncurry (Coq.variable . return)) Coq.Base.freeArgs

--- a/src/lib/FreeC/Environment.hs
+++ b/src/lib/FreeC/Environment.hs
@@ -40,13 +40,10 @@ module FreeC.Environment
   )
 where
 
-import           Control.Monad                  ( (<=<)
-                                                , guard
-                                                )
+import           Control.Monad                  ( (<=<) )
 import           Data.Composition               ( (.:)
                                                 , (.:.)
                                                 )
-import           Data.Functor                   ( ($>) )
 import           Data.List                      ( find )
 import           Data.Map.Strict                ( Map )
 import qualified Data.Map.Strict               as Map
@@ -194,7 +191,7 @@ usedIdents = concatMap entryIdents . Map.elems . envEntries
  where
   entryIdents :: EnvEntry -> [Coq.Qualid]
   entryIdents entry =
-    entryIdent entry : (guard (isConEntry entry) $> entrySmartIdent entry)
+    entryIdent entry : [ entrySmartIdent entry | isConEntry entry ]
 
 -- | Gets a list of Agda identifiers for functions, (type/smart) constructors,
 --   (type/fresh) variables that were used in the given environment already.
@@ -203,8 +200,7 @@ usedAgdaIdents = concatMap entryIdents . Map.elems . envEntries
  where
   entryIdents :: EnvEntry -> [Agda.QName]
   entryIdents entry =
-    entryAgdaIdent entry
-      : (guard (isConEntry entry) $> entryAgdaSmartIdent entry)
+    entryAgdaIdent entry : [ entryAgdaSmartIdent entry | isConEntry entry ]
 
 -- | Looks up the location of the declaration with the given name.
 lookupSrcSpan :: IR.Scope -> IR.QName -> Environment -> Maybe SrcSpan

--- a/src/lib/FreeC/Environment.hs
+++ b/src/lib/FreeC/Environment.hs
@@ -20,6 +20,7 @@ module FreeC.Environment
   , isVariable
   , isPureVar
   , lookupIdent
+  , lookupAgdaIdent
   , lookupSmartIdent
   , usedIdents
   , lookupSrcSpan
@@ -50,6 +51,7 @@ import           Data.Maybe                     ( catMaybes
                                                 )
 import           Data.Tuple.Extra               ( (&&&) )
 
+import qualified FreeC.Backend.Agda.Syntax     as Agda
 import qualified FreeC.Backend.Coq.Syntax      as Coq
 import           FreeC.Environment.Entry
 import           FreeC.Environment.ModuleInterface
@@ -169,6 +171,9 @@ isPureVar =
 --   constructor or (type) variable with the given name.
 lookupIdent :: IR.Scope -> IR.QName -> Environment -> Maybe Coq.Qualid
 lookupIdent = fmap entryIdent .:. lookupEntry
+
+lookupAgdaIdent :: IR.Scope -> IR.QName -> Environment -> Maybe Agda.QName
+lookupAgdaIdent = fmap entryAgdaIdent .:. lookupEntry
 
 -- | Looks up the Coq identifier for the smart constructor of the Haskell
 --   constructor with the given name.

--- a/src/lib/FreeC/Environment.hs
+++ b/src/lib/FreeC/Environment.hs
@@ -23,6 +23,7 @@ module FreeC.Environment
   , lookupAgdaIdent
   , lookupSmartIdent
   , usedIdents
+  , usedAgdaIdents
   , lookupSrcSpan
   , lookupTypeArgs
   , lookupTypeArgArity
@@ -192,6 +193,16 @@ usedIdents = concatMap entryIdents . Map.elems . envEntries
   entryIdents entry
     | isConEntry entry = [entryIdent entry, entrySmartIdent entry]
     | otherwise        = [entryIdent entry]
+
+-- | Gets a list of Agda identifiers for functions, (type/smart) constructors,
+--   (type/fresh) variables that were used in the given environment already.
+usedAgdaIdents :: Environment -> [Agda.QName]
+usedAgdaIdents = concatMap entryIdents . Map.elems . envEntries
+ where
+  entryIdents :: EnvEntry -> [Agda.QName]
+  entryIdents entry
+    | isConEntry entry = [entryAgdaIdent entry, entryAgdaSmartIdent entry]
+    | otherwise        = [entryAgdaIdent entry]
 
 -- | Looks up the location of the declaration with the given name.
 lookupSrcSpan :: IR.Scope -> IR.QName -> Environment -> Maybe SrcSpan

--- a/src/lib/FreeC/Environment/LookupOrFail.hs
+++ b/src/lib/FreeC/Environment/LookupOrFail.hs
@@ -1,7 +1,6 @@
 -- | This module contains functions to lookup entries of the 'Environment'
 --   that (in contrast to the functions defined in "FreeC.Environment")
 --   report a fatal error message when there is no such entry.
-
 module FreeC.Environment.LookupOrFail where
 
 import qualified FreeC.Backend.Agda.Syntax     as Agda
@@ -38,12 +37,11 @@ lookupEntryOrFail srcSpan scope name = do
 --   If an error is reported, it points to the given source span.
 lookupIdentOrFail
   :: SrcSpan  -- ^ The source location where the identifier is requested.
-  -> IR.Scope    -- ^ The scope to look the identifier up in.
+  -> IR.Scope -- ^ The scope to look the identifier up in.
   -> IR.QName -- ^ The Haskell identifier to look up.
   -> Converter Coq.Qualid
-lookupIdentOrFail srcSpan scope name = do
-  entry <- lookupEntryOrFail srcSpan scope name
-  return (entryIdent entry)
+lookupIdentOrFail srcSpan scope name =
+  entryIdent <$> lookupEntryOrFail srcSpan scope name
 
 -- | Looks up the Agda identifier for a Haskell function, (type)
 --   constructor or (type) variable with the given name or reports a fatal
@@ -52,12 +50,11 @@ lookupIdentOrFail srcSpan scope name = do
 --   If an error is reported, it points to the given source span.
 lookupAgdaIdentOrFail
   :: SrcSpan  -- ^ The source location where the identifier is requested.
-  -> IR.Scope    -- ^ The scope to look the identifier up in.
+  -> IR.Scope -- ^ The scope to look the identifier up in.
   -> IR.QName -- ^ The Haskell identifier to look up.
   -> Converter Agda.QName
-lookupAgdaIdentOrFail srcSpan scope name = do
-  entry <- lookupEntryOrFail srcSpan scope name
-  return (entryAgdaIdent entry)
+lookupAgdaIdentOrFail srcSpan scope name =
+  entryAgdaIdent <$> lookupEntryOrFail srcSpan scope name
 
 -- | Looks up the Coq identifier of a smart constructor of the Haskell
 --   data constructr with the given name or reports a fatal error message
@@ -68,6 +65,6 @@ lookupSmartIdentOrFail
   :: SrcSpan  -- ^ The source location where the identifier is requested.
   -> IR.QName -- ^ The Haskell identifier to look up.
   -> Converter Coq.Qualid
-lookupSmartIdentOrFail srcSpan name = do
-  entry <- lookupEntryOrFail srcSpan IR.ValueScope name
-  return (entrySmartIdent entry)
+lookupSmartIdentOrFail srcSpan name =
+  entrySmartIdent <$> lookupEntryOrFail srcSpan IR.ValueScope name
+

--- a/src/lib/FreeC/Environment/LookupOrFail.hs
+++ b/src/lib/FreeC/Environment/LookupOrFail.hs
@@ -4,6 +4,7 @@
 
 module FreeC.Environment.LookupOrFail where
 
+import qualified FreeC.Backend.Agda.Syntax     as Agda
 import qualified FreeC.Backend.Coq.Syntax      as Coq
 import           FreeC.Environment
 import           FreeC.Environment.Entry
@@ -43,6 +44,20 @@ lookupIdentOrFail
 lookupIdentOrFail srcSpan scope name = do
   entry <- lookupEntryOrFail srcSpan scope name
   return (entryIdent entry)
+
+-- | Looks up the Agda identifier for a Haskell function, (type)
+--   constructor or (type) variable with the given name or reports a fatal
+--   error message if the identifier has not been defined.
+--
+--   If an error is reported, it points to the given source span.
+lookupAgdaIdentOrFail
+  :: SrcSpan  -- ^ The source location where the identifier is requested.
+  -> IR.Scope    -- ^ The scope to look the identifier up in.
+  -> IR.QName -- ^ The Haskell identifier to look up.
+  -> Converter Agda.QName
+lookupAgdaIdentOrFail srcSpan scope name = do
+  entry <- lookupEntryOrFail srcSpan scope name
+  return (entryAgdaIdent entry)
 
 -- | Looks up the Coq identifier of a smart constructor of the Haskell
 --   data constructr with the given name or reports a fatal error message

--- a/src/lib/FreeC/Environment/Renamer.hs
+++ b/src/lib/FreeC/Environment/Renamer.hs
@@ -184,13 +184,18 @@ renameAgdaIdent :: Agda.QName -> Environment -> Agda.QName
 renameAgdaIdent ident env =
   if (Agda.unqualify ident `elem` Agda.Base.reservedIdents)
        || isUsedAgdaIdent env ident
-    then renameAgdaIdent (Agda.nextQName ident) env
+    then renameAgdaIdent (nextQName ident) env
     else ident
 
 -- | Generates a new Agda identifier based on the given @String@, the used
 --   @Agda.QName@s from the environment and reserved identifier.
 renameAgdaQualid :: String -> Environment -> Agda.QName
 renameAgdaQualid name = renameAgdaIdent (Agda.qname' $ Agda.name name)
+
+-- | Creates a new qualified name, by appending a number or incrementing it.
+nextQName :: Agda.QName -> Agda.QName
+nextQName (Agda.Qual modName qName) = Agda.Qual modName $ nextQName qName
+nextQName (Agda.QName unQName     ) = Agda.QName $ Agda.nextName unQName
 
 -------------------------------------------------------------------------------
 -- Define and automatically rename identifiers                               --

--- a/src/lib/FreeC/Environment/Renamer.hs
+++ b/src/lib/FreeC/Environment/Renamer.hs
@@ -5,7 +5,7 @@
 --   types, constructors and functions from the Base library.
 --
 --   Renaming identifiers is also required because in Haskell the scopes for
---   types and functions are separated. Thus Git is allowed in Haskell for a
+--   types and functions are separated. Thus it is allowed in Haskell for a
 --   data type to have the same name as one of it's constructors. In Coq this
 --   would cause a name conflict. Therefore, one of them needs to be renamed.
 

--- a/src/lib/FreeC/Environment/Renamer.hs
+++ b/src/lib/FreeC/Environment/Renamer.hs
@@ -32,6 +32,7 @@ import           Data.Maybe                     ( fromMaybe
 import           Text.Casing
 import           Text.RegexPR
 
+import qualified FreeC.Backend.Agda.Syntax     as Agda
 import qualified FreeC.Backend.Coq.Base        as Coq.Base
 import           FreeC.Backend.Coq.Keywords
 import qualified FreeC.Backend.Coq.Syntax      as Coq
@@ -171,6 +172,9 @@ renameIdent' ident n env
 renameQualid :: String -> Environment -> Coq.Qualid
 renameQualid = Coq.bare .: renameIdent
 
+renameAgdaQualid :: String -> Environment -> Agda.QName
+renameAgdaQualid name _ = Agda.qname [] $ Agda.name name
+
 -------------------------------------------------------------------------------
 -- Define and automatically rename identifiers                               --
 -------------------------------------------------------------------------------
@@ -188,7 +192,9 @@ renameEntry entry env
   | isVarEntry entry || isTypeVarEntry entry = entry
     { entryIdent = renameQualid ident env
     }
-  | otherwise = entry { entryIdent = renameQualid ident env }
+  | otherwise = entry { entryIdent     = renameQualid ident env
+                      , entryAgdaIdent = renameAgdaQualid ident env
+                      }
  where
   ident :: String
   ident = fromMaybe "op" $ IR.identFromQName (entryName entry)

--- a/src/lib/FreeC/Environment/Renamer.hs
+++ b/src/lib/FreeC/Environment/Renamer.hs
@@ -203,8 +203,10 @@ renameAgdaQualid name = renameAgdaIdent (Agda.qname' $ Agda.name name)
 renameEntry :: EnvEntry -> Environment -> EnvEntry
 renameEntry entry env
   | isConEntry entry = entry
-    { entryIdent      = renameQualid (toCamel (fromHumps ident)) env
-    , entrySmartIdent = renameQualid ident env
+    { entryIdent          = renameQualid (toCamel (fromHumps ident)) env
+    , entrySmartIdent     = renameQualid ident env
+    , entryAgdaIdent      = renameAgdaQualid (toCamel (fromHumps ident)) env
+    , entryAgdaSmartIdent = renameAgdaQualid ident env
     }
   | isVarEntry entry || isTypeVarEntry entry = entry
     { entryIdent     = renameQualid ident env


### PR DESCRIPTION
Adds translation for non recursive function signatures. Creates a base for converting further module entries. Blocked by #48. Closes #54 