### PR TITLE
Add check for kinds of type expressions #22

### DIFF
--- a/free-compiler.cabal
+++ b/free-compiler.cabal
@@ -170,6 +170,7 @@ library freec-internal
                       , FreeC.Pass.ExportPass
                       , FreeC.Pass.ImplicitPreludePass
                       , FreeC.Pass.ImportPass
+                      , FreeC.Pass.KindInferencePass
                       , FreeC.Pass.PartialityAnalysisPass
                       , FreeC.Pass.TypeInferencePass
                       , FreeC.Pass.TypeSignaturePass

--- a/free-compiler.cabal
+++ b/free-compiler.cabal
@@ -170,7 +170,7 @@ library freec-internal
                       , FreeC.Pass.ExportPass
                       , FreeC.Pass.ImplicitPreludePass
                       , FreeC.Pass.ImportPass
-                      , FreeC.Pass.KindInferencePass
+                      , FreeC.Pass.KindCheckPass
                       , FreeC.Pass.PartialityAnalysisPass
                       , FreeC.Pass.TypeInferencePass
                       , FreeC.Pass.TypeSignaturePass

--- a/free-compiler.cabal
+++ b/free-compiler.cabal
@@ -170,6 +170,7 @@ library freec-internal
                       , FreeC.Pass.ExportPass
                       , FreeC.Pass.ImplicitPreludePass
                       , FreeC.Pass.ImportPass
+                      , FreeC.Pass.KindCheckPass
                       , FreeC.Pass.PartialityAnalysisPass
                       , FreeC.Pass.TypeInferencePass
                       , FreeC.Pass.TypeSignaturePass
@@ -234,6 +235,7 @@ test-suite freec-unit-tests
                     , FreeC.Monad.Class.Testable
                     , FreeC.Monad.ReporterTests
                     , FreeC.Pass.EtaConversionPassTests
+                    , FreeC.Pass.KindCheckPassTests
                     , FreeC.Pass.PartialityAnalysisPassTests
                     , FreeC.Pass.ResolverPassTests
                     , FreeC.Pass.TypeInferencePassTests

--- a/src/lib/FreeC/Pass/KindCheckPass.hs
+++ b/src/lib/FreeC/Pass/KindCheckPass.hs
@@ -139,7 +139,7 @@ checkAlt (IR.Alt _ _ varPats rhs) = do
 
 -- | Checks whether the type annotation of a variable pattern is kind-correct.
 checkVarPat :: IR.VarPat -> Converter ()
-checkVarPat (IR.VarPat _ _ typ) = mapM_ checkType typ
+checkVarPat (IR.VarPat _ _ typ _) = mapM_ checkType typ
 
 -- | Checks if all type constructors have the correct number of arguments
 checkType :: IR.Type -> Converter ()

--- a/src/lib/FreeC/Pass/KindCheckPass.hs
+++ b/src/lib/FreeC/Pass/KindCheckPass.hs
@@ -51,8 +51,8 @@
 --   All type constructors in type expressions are applied to the correct
 --   number of arguments and there are no type variables or function types on
 --   the left-hand side of type applications.
-module FreeC.Pass.KindInferencePass
-  ( kindInferencePass
+module FreeC.Pass.KindCheckPass
+  ( kindCheckPass
   )
 where
 
@@ -66,11 +66,11 @@ import           FreeC.Monad.Reporter
 import           FreeC.Pass
 import           FreeC.Pretty                   ( showPretty )
 
--- | A compiler pass that checks wheter there are type applications with type
+-- | A compiler pass that checks whether there are type applications with type
 --   variables or function types on the left-hand side in the module and checks
 --   whether all type construcors in the module are fully applied.
-kindInferencePass :: Pass IR.Module
-kindInferencePass m@(IR.Module _ _ _ typeDecls typeSigs _ funcDecls) = do
+kindCheckPass :: Pass IR.Module
+kindCheckPass m@(IR.Module _ _ _ typeDecls typeSigs _ funcDecls) = do
   mapM_ checkTypeDecl typeDecls
   mapM_ checkTypeSig  typeSigs
   mapM_ checkFuncDecl funcDecls

--- a/src/lib/FreeC/Pass/KindCheckPass.hs
+++ b/src/lib/FreeC/Pass/KindCheckPass.hs
@@ -1,4 +1,3 @@
-
 -- | This module contains a compiler pass that checks if all type constructors
 --   in type expressions are fully applied and type variables are not applied.
 --
@@ -18,7 +17,7 @@
 --   >
 --   > data MyList a = MyNil | MyCons a (MyList a)
 --   >
---   > -- Invalid because 'MyList' is applied to 2 arguments
+--   > -- Invalid because 'MyList' is applied to 2 arguments.
 --   > fail1 :: MyList (MyList a a) -> Integer
 --   > fail1 x = 42
 --   >
@@ -81,7 +80,7 @@ kindCheckPass m@(IR.Module _ _ _ typeDecls typeSigs _ funcDecls) = do
 -- | Checks whether all type expressions in a type declaration are correct.
 checkTypeDecl :: IR.TypeDecl -> Converter ()
 checkTypeDecl (IR.DataDecl    _ _ _ conDecls) = mapM_ checkConDecl conDecls
-checkTypeDecl (IR.TypeSynDecl _ _ _ typ     ) = checkType typ
+checkTypeDecl (IR.TypeSynDecl _ _ _ typeExpr) = checkType typeExpr
 
 -- | Checks whether the arguments of a constructor declaration are kind-correct.
 checkConDecl :: IR.ConDecl -> Converter ()

--- a/src/lib/FreeC/Pass/KindCheckPass.hs
+++ b/src/lib/FreeC/Pass/KindCheckPass.hs
@@ -1,0 +1,11 @@
+module FreeC.Pass.KindCheckPass where
+
+import qualified FreeC.IR.Syntax               as IR
+import           FreeC.Monad.Converter
+import           FreeC.Pass
+
+kindCheckPass :: Pass IR.Module
+kindCheckPass = return
+
+checkType :: IR.Type -> Converter ()
+checkType _ = return ()

--- a/src/lib/FreeC/Pass/KindInferencePass.hs
+++ b/src/lib/FreeC/Pass/KindInferencePass.hs
@@ -1,5 +1,6 @@
-module Freec.Pass.KindInferencePass
-  ()
+module FreeC.Pass.KindInferencePass
+  ( kindInferencePass
+  )
 where
 
 import qualified FreeC.IR.Syntax               as IR
@@ -9,95 +10,99 @@ import           FreeC.Pass
 import           FreeC.Pretty
 
 kindInferencePass :: Pass IR.Module
-kindInferencePass (Module _ _ _ typeDecls typeSigs _ funcDecls) = do
+kindInferencePass m@(IR.Module _ _ _ typeDecls typeSigs _ funcDecls) = do
   checkTypeDecls typeDecls
   checkTypeSigs typeSigs
   checkFuncDecls funcDecls
+  return m
 
 checkTypeDecls :: Monad m => m IR.TypeDecl -> Converter ()
-checkTypeDecls typeDecls = mapM_ checkTypeDecl typeDecls
+checkTypeDecls = mapM_ checkTypeDecl
 
 checkTypeSigs :: Monad m => m IR.TypeSig -> Converter ()
-checkTypeSigs typeSigs = mapM_ checkTypeSig typeSigs
+checkTypeSigs = mapM_ checkTypeSig
 
 checkFuncDecls :: Monad m => m IR.FuncDecl -> Converter ()
-checkFuncDecls funcDecls = mapM_ checkFuncDecl funcDecls
+checkFuncDecls = mapM_ checkFuncDecl
 
 checkTypes :: Monad m => m IR.Type -> Converter ()
-checkTypes types = mapM_ containsLeftTypeVars types
+checkTypes = mapM_ containsLeftTypeVars
 
 checkTypeDecl :: IR.TypeDecl -> Converter ()
-checkTypeDecl (DataDecl    _ _ _ conDecls) = mapM_ checkConDecl conDecls
-checkTypeDecl (TypeSynDecl _ _ _ typ     ) = containsLeftTypeVars typ
+checkTypeDecl (IR.DataDecl    _ _ _ conDecls) = mapM_ checkConDecl conDecls
+checkTypeDecl (IR.TypeSynDecl _ _ _ typ     ) = containsLeftTypeVars typ
 
 checkConDecl :: IR.ConDecl -> Converter ()
-checkConDecl (ConDecl _ _ types) = mapM_ containsLeftTypeVars types
+checkConDecl (IR.ConDecl _ _ types) = mapM_ containsLeftTypeVars types
 
 checkTypeSig :: IR.TypeSig -> Converter ()
-checkTypeSig (TypeSig _ _ typeSchema) = checkTypeSchema typeSchema
+checkTypeSig (IR.TypeSig _ _ typeSchema) = checkTypeSchema typeSchema
 
 checkTypeSchema :: IR.TypeSchema -> Converter ()
-checkTypeSchema (TypeSchema _ _ typ) = containsLeftTypeVars typ
+checkTypeSchema (IR.TypeSchema _ _ typ) = containsLeftTypeVars typ
 
 checkFuncDecl :: IR.FuncDecl -> Converter ()
-checkFuncDecl (FuncDecl _ _ _ varPats retType rhs) = do
+checkFuncDecl (IR.FuncDecl _ _ _ varPats retType rhs) = do
   checkVarPats varPats
   checkTypes retType
   checkExpr rhs
   return ()
 
 checkExpr :: IR.Expr -> Converter ()
-checkExpr (Con _ _ typeSchema      ) = mapM_ checkTypeSchema typeSchema
-checkExpr (Var _ _ typeSchema      ) = mapM_ checkTypeSchema typeSchema
-checkExpr (App _ lhs rhs typeSchema) = do
+checkExpr (IR.Con _ _ typeSchema      ) = mapM_ checkTypeSchema typeSchema
+checkExpr (IR.Var _ _ typeSchema      ) = mapM_ checkTypeSchema typeSchema
+checkExpr (IR.App _ lhs rhs typeSchema) = do
   checkExpr lhs
   checkExpr rhs
   mapM_ checkTypeSchema typeSchema
-  return ()
-checkExpr (TypeAppExpr _ lhs rhs typeSchema) = do
+checkExpr (IR.TypeAppExpr _ lhs rhs typeSchema) = do
   checkExpr lhs
   containsLeftTypeVars rhs
   mapM_ checkTypeSchema typeSchema
-  return ()
-checkExpr (If _ cond thenExp elseExp typeSchema) = do
+checkExpr (IR.If _ cond thenExp elseExp typeSchema) = do
   checkExpr cond
   checkExpr thenExp
   checkExpr elseExp
   mapM_ checkTypeSchema typeSchema
-  return ()
-checkExpr (Case _ scrutinee alts typeSchema) = do
+checkExpr (IR.Case _ scrutinee alts typeSchema) = do
   checkExpr scrutinee
   checkAlts alts
   mapM_ checkTypeSchema typeSchema
-  return ()
-checkExpr (Undefined _ typeSchema      ) = mapM_ checkTypeSchema typeSchema
-checkExpr (ErrorExpr  _ _ typeSchema   ) = mapM_ checkTypeSchema typeSchema
-checkExpr (IntLiteral _ _ typeSchema   ) = mapM_ checkTypeSchema typeSchema
-checkExpr (Lambda _ args rhs typeSchema) = do
+checkExpr (IR.Undefined _ typeSchema      ) = mapM_ checkTypeSchema typeSchema
+checkExpr (IR.ErrorExpr  _ _ typeSchema   ) = mapM_ checkTypeSchema typeSchema
+checkExpr (IR.IntLiteral _ _ typeSchema   ) = mapM_ checkTypeSchema typeSchema
+checkExpr (IR.Lambda _ args rhs typeSchema) = do
   checkVarPats args
   checkExpr rhs
   mapM_ checkTypeSchema typeSchema
-  return ()
+
+checkAlts :: Monad m => m IR.Alt -> Converter ()
+checkAlts = mapM_ checkAlt
+
+checkAlt :: IR.Alt -> Converter ()
+checkAlt (IR.Alt _ _ varPats rhs) = do
+  checkVarPats varPats
+  checkExpr rhs
 
 checkVarPats :: Monad m => m IR.VarPat -> Converter ()
-checkVarPats varPats = mapM_ checkVarPat varPats
+checkVarPats = mapM_ checkVarPat
 
-checkVarPat :: VarPat -> Converter ()
-checkVarPat (VarPat _ _ typ) = checkTypes typ
+checkVarPat :: IR.VarPat -> Converter ()
+checkVarPat (IR.VarPat _ _ typ) = checkTypes typ
 
 
 containsLeftTypeVars :: IR.Type -> Converter ()
-containsLeftTypeVars (TypeVar _ _) = return ()
-containsLeftTypeVars (TypeCon _ _) = return ()
-containsLeftTypeVars (TypeApp _ (TypeVar srcSpan varId) _) =
+containsLeftTypeVars (IR.TypeVar _ _) = return ()
+containsLeftTypeVars (IR.TypeCon _ _) = return ()
+containsLeftTypeVars (IR.TypeApp _ (IR.TypeVar srcSpan varId) _) =
   reportFatal
     $  Message srcSpan Error
     $  "Type variable "
-    ++ varid
+    ++ varId
     ++ " occurs on right-hand"
     ++ " side of type application"
-containsLeftTypeVars (TypeApp _ lhs _) = do
+containsLeftTypeVars (IR.TypeApp _ lhs _) = do
   containsLeftTypeVars lhs
-containsLeftTypeVars (FuncType _ lhs rhs) = do
+containsLeftTypeVars (IR.FuncType _ lhs rhs) = do
   containsLeftTypeVars lhs
   containsLeftTypeVars rhs

--- a/src/lib/FreeC/Pass/KindInferencePass.hs
+++ b/src/lib/FreeC/Pass/KindInferencePass.hs
@@ -3,15 +3,18 @@ module Freec.Pass.KindInferencePass
     ) where
 
 import qualified FreeC.IR.Syntax as IR
-
+import           FreeC.Monad.Converter
+import           FreeC.Monad.Reporter
+import           FreeC.Pass
+import           FreeC.Pretty
 
 kindInferencePass :: Pass IR.Module
 kindInferencePass = undefined
 
-containsLeftTypeVars :: IR.Type -> Bool
-containsLeftTypeVars (TypeVar _ _)               = False
-containsLeftTypeVars (TypeCon _ _)               = False
-containsLeftTypeVars (TypeApp _ (TypeVar _ _) _) = True
+containsLeftTypeVars :: IR.Type -> Converter ()
+containsLeftTypeVars (TypeVar _ _)               = return ()
+containsLeftTypeVars (TypeCon _ _)               = return ()
+containsLeftTypeVars (TypeApp _ (TypeVar _ _) _) = reportLeftVarError
 containsLeftTypeVars (TypeApp _ lhs _)           = containsLeftTypeVars lhs
 containsLeftTypeVars (FuncType _ lhs rhs)        = containsLeftTypeVars lhs ||
                                                    containsLeftTypeVars rhs

--- a/src/lib/FreeC/Pass/KindInferencePass.hs
+++ b/src/lib/FreeC/Pass/KindInferencePass.hs
@@ -1,0 +1,17 @@
+module Freec.Pass.KindInferencePass
+    (
+    ) where
+
+import qualified FreeC.IR.Syntax as IR
+
+
+kindInferencePass :: Pass IR.Module
+kindInferencePass = undefined
+
+containsLeftTypeVars :: IR.Type -> Bool
+containsLeftTypeVars (TypeVar _ _)               = False
+containsLeftTypeVars (TypeCon _ _)               = False
+containsLeftTypeVars (TypeApp _ (TypeVar _ _) _) = True
+containsLeftTypeVars (TypeApp _ lhs _)           = containsLeftTypeVars lhs
+containsLeftTypeVars (FuncType _ lhs rhs)        = containsLeftTypeVars lhs ||
+                                                   containsLeftTypeVars rhs

--- a/src/lib/FreeC/Pass/KindInferencePass.hs
+++ b/src/lib/FreeC/Pass/KindInferencePass.hs
@@ -1,3 +1,52 @@
+
+-- | This module contains a compiler pass that checks if all type constructors
+--   in type expressions are fully applied and type variables are not applied.
+--
+--   For simplification, all type variables have kind @*@. Therefore, all type
+--   constructors must be fully applied, so partial application of type
+--   constructors is not allowed. This pass also checks that type variables and
+--   function types do not occur on the left hand side of a type application.
+--   If a type expression is found that does not match this rules, a fatal
+--   error is thrown. For simplification, a type expression that satisfies all
+--   of these rules is called kind-correct.
+--
+--   = Example
+--
+--   The following module contains three invalid definitions
+--
+--   > module Failures where
+--   >
+--   > data MyList a = MyNil | MyCons a (MyList a)
+--   >
+--   > fail1 :: MyList (MyList a a) -> Integer
+--   > fail1 x = 42
+--   >
+--   > fail2 :: a a -> Integer
+--   > fail2 x = 42
+--   >
+--   > fail3 :: MyList -> Integer
+--   > fail3 x = 42
+--
+--   = Specification
+--
+--   == Preconditions
+--
+--   The environment must contain all type declarations that are used in the
+--   module
+--
+--   == Translations
+--
+--   The AST is not changed. It is checked if all type constructor applications
+--   have the right number of arguments. It is also checked whether there are
+--   type variables or function types on the left-hand side of type
+--   applications. In these cases, a fatal error is thrown. Otherwise, the
+--   pass finishes with the given module unchanged.
+--
+--   == Postcondition
+--
+--   All type constructors in type expressions are applied to the correct
+--   number of arguments and there are no type variables or function types on
+--   the left-hand side of type applications. 
 module FreeC.Pass.KindInferencePass
   ( kindInferencePass
   )
@@ -13,6 +62,9 @@ import           FreeC.Monad.Reporter
 import           FreeC.Pass
 import           FreeC.Pretty                   ( showPretty )
 
+-- | A compiler pass that checks wheter there are type applications with type
+--   variables or function types on the left-hand side in the module and checks
+--   whether all type construcors in the module are fully applied.
 kindInferencePass :: Pass IR.Module
 kindInferencePass m@(IR.Module _ _ _ typeDecls typeSigs _ funcDecls) = do
   checkTypeDecls typeDecls
@@ -20,36 +72,48 @@ kindInferencePass m@(IR.Module _ _ _ typeDecls typeSigs _ funcDecls) = do
   checkFuncDecls funcDecls
   return m
 
+-- |
 checkMaybeTypeSchema :: Maybe IR.TypeSchema -> Converter ()
 checkMaybeTypeSchema Nothing  = return ()
 checkMaybeTypeSchema (Just x) = checkTypeSchema x
 
+-- | Checks whether an optional type expression is kind correct in case the
+--   type expression is present
 checkMaybeType :: Maybe IR.Type -> Converter ()
 checkMaybeType Nothing  = return ()
 checkMaybeType (Just x) = checkType x
 
+-- | Checks whether all type declarations have kind-correct type expressions
 checkTypeDecls :: [IR.TypeDecl] -> Converter ()
 checkTypeDecls = mapM_ checkTypeDecl
 
+-- | Checks whether all type signatures have kind-correct types
 checkTypeSigs :: [IR.TypeSig] -> Converter ()
 checkTypeSigs = mapM_ checkTypeSig
 
+-- | Checks whether all function declarations have kind-correct type
+--   annotations
 checkFuncDecls :: [IR.FuncDecl] -> Converter ()
 checkFuncDecls = mapM_ checkFuncDecl
 
+-- | Checks whether all type expressions in a type declaration are correct
 checkTypeDecl :: IR.TypeDecl -> Converter ()
 checkTypeDecl (IR.DataDecl    _ _ _ conDecls) = mapM_ checkConDecl conDecls
 checkTypeDecl (IR.TypeSynDecl _ _ _ typ     ) = checkType typ
 
+-- | Checks whether the arguments of a constructor declaration are kind-correct
 checkConDecl :: IR.ConDecl -> Converter ()
 checkConDecl (IR.ConDecl _ _ types) = mapM_ checkType types
 
+-- | Checks whether the type schema in a type signature is kind-correct
 checkTypeSig :: IR.TypeSig -> Converter ()
 checkTypeSig (IR.TypeSig _ _ typeSchema) = checkTypeSchema typeSchema
 
+-- | Checks whether a given type schema is kind-correct
 checkTypeSchema :: IR.TypeSchema -> Converter ()
 checkTypeSchema (IR.TypeSchema _ _ typ) = checkType typ
 
+-- | Checks whether a function declaration has kind-correct type annotations
 checkFuncDecl :: IR.FuncDecl -> Converter ()
 checkFuncDecl (IR.FuncDecl _ _ _ varPats retType rhs) = do
   checkVarPats varPats
@@ -57,6 +121,7 @@ checkFuncDecl (IR.FuncDecl _ _ _ varPats retType rhs) = do
   checkExpr rhs
   return ()
 
+-- | Checks whether all type annotations in an expression are kind-correct
 checkExpr :: IR.Expr -> Converter ()
 checkExpr (IR.Con _ _ typeSchema      ) = checkMaybeTypeSchema typeSchema
 checkExpr (IR.Var _ _ typeSchema      ) = checkMaybeTypeSchema typeSchema
@@ -85,27 +150,34 @@ checkExpr (IR.Lambda _ args rhs typeSchema) = do
   checkExpr rhs
   checkMaybeTypeSchema typeSchema
 
+-- | Performs @checkAlt@ on all elements of the given list.
 checkAlts :: [IR.Alt] -> Converter ()
 checkAlts = mapM_ checkAlt
 
+-- | Checks whether the variable patterns have correct type annotations and the
+--   expression has kind-correct type annotations
 checkAlt :: IR.Alt -> Converter ()
 checkAlt (IR.Alt _ _ varPats rhs) = do
   checkVarPats varPats
   checkExpr rhs
 
+-- | Performs @checkVarPat@ on all elems in the given list.
 checkVarPats :: [IR.VarPat] -> Converter ()
 checkVarPats = mapM_ checkVarPat
 
+-- | Checks whether the type annotation of a variable pattern is kind-correct.
 checkVarPat :: IR.VarPat -> Converter ()
 checkVarPat (IR.VarPat _ _ typ) = checkMaybeType typ
 
+-- | Checks whether a type is kind-correct
 checkType :: IR.Type -> Converter ()
 checkType = checkCorrectArities
 
-
+-- | Checks if all type constructors have the correct number of arguments
 checkCorrectArities :: IR.Type -> Converter ()
-checkCorrectArities = checkCorrectArities' 0 -- to be implemented
+checkCorrectArities = checkCorrectArities' 0
 
+-- | Helper function for @checkCorrectArities@
 checkCorrectArities' :: Int -> IR.Type -> Converter ()
 checkCorrectArities' depth (IR.TypeVar srcSpan varId) =
   when (depth /= 0)

--- a/src/lib/FreeC/Pass/KindInferencePass.hs
+++ b/src/lib/FreeC/Pass/KindInferencePass.hs
@@ -9,7 +9,7 @@ import           FreeC.Pass
 import           FreeC.Pretty
 
 kindInferencePass :: Pass IR.Module
-kindInferencePass (Module _ _ _ typeDecls typeSigs  _ funcDecls ) = do
+kindInferencePass (Module _ _ _ typeDecls typeSigs _ funcDecls) = do
   checkTypeDecls typeDecls
   checkTypeSigs typeSigs
   checkFuncDecls funcDecls
@@ -27,8 +27,8 @@ checkTypes :: Monad m => m IR.Type -> Converter ()
 checkTypes types = mapM_ containsLeftTypeVars types
 
 checkTypeDecl :: IR.TypeDecl -> Converter ()
-checkTypeDecl (DataDecl _ _ _ conDecls) = mapM_ checkConDecl conDecls
-checkTypeDecl (TypeSynDecl _ _ _ typ) = containsLeftTypeVars typ
+checkTypeDecl (DataDecl    _ _ _ conDecls) = mapM_ checkConDecl conDecls
+checkTypeDecl (TypeSynDecl _ _ _ typ     ) = containsLeftTypeVars typ
 
 checkConDecl :: IR.ConDecl -> Converter ()
 checkConDecl (ConDecl _ _ types) = mapM_ containsLeftTypeVars types
@@ -40,15 +40,15 @@ checkTypeSchema :: IR.TypeSchema -> Converter ()
 checkTypeSchema (TypeSchema _ _ typ) = containsLeftTypeVars typ
 
 checkFuncDecl :: IR.FuncDecl -> Converter ()
-checkFuncDecl (_ _ _ varPats retType rhs) = do
+checkFuncDecl (FuncDecl _ _ _ varPats retType rhs) = do
   checkVarPats varPats
   checkTypes retType
   checkExpr rhs
   return ()
 
 checkExpr :: IR.Expr -> Converter ()
-checkExpr (Con _ _ typeSchema) = mapM_ checkTypeSchema typeSchema
-checkExpr (Var _ _ typeSchema) = mapM_ checkTypeSchema typeSchema
+checkExpr (Con _ _ typeSchema      ) = mapM_ checkTypeSchema typeSchema
+checkExpr (Var _ _ typeSchema      ) = mapM_ checkTypeSchema typeSchema
 checkExpr (App _ lhs rhs typeSchema) = do
   checkExpr lhs
   checkExpr rhs
@@ -70,9 +70,9 @@ checkExpr (Case _ scrutinee alts typeSchema) = do
   checkAlts alts
   mapM_ checkTypeSchema typeSchema
   return ()
-checkExpr (Undefined _ typeSchema) = mapM_ checkTypeSchema typeSchema
-checkExpr (ErrorExpr _ _ typeSchema) = mapM_ checkTypeSchema typeSchema
-checkExpr (IntLiteral _ _ typeSchema) = mapM_ checkTypeSchema typeSchema
+checkExpr (Undefined _ typeSchema      ) = mapM_ checkTypeSchema typeSchema
+checkExpr (ErrorExpr  _ _ typeSchema   ) = mapM_ checkTypeSchema typeSchema
+checkExpr (IntLiteral _ _ typeSchema   ) = mapM_ checkTypeSchema typeSchema
 checkExpr (Lambda _ args rhs typeSchema) = do
   checkVarPats args
   checkExpr rhs

--- a/src/lib/FreeC/Pass/KindInferencePass.hs
+++ b/src/lib/FreeC/Pass/KindInferencePass.hs
@@ -16,11 +16,11 @@ kindInferencePass m@(IR.Module _ _ _ typeDecls typeSigs _ funcDecls) = do
   return m
 
 checkMaybeTypeSchema :: Maybe IR.TypeSchema -> Converter ()
-checkMaybeTypeSchema Nothing = return ()
+checkMaybeTypeSchema Nothing  = return ()
 checkMaybeTypeSchema (Just x) = checkTypeSchema x
 
 checkMaybeType :: Maybe IR.Type -> Converter ()
-checkMaybeType Nothing = return ()
+checkMaybeType Nothing  = return ()
 checkMaybeType (Just x) = containsLeftTypeVars x
 
 checkTypeDecls :: [IR.TypeDecl] -> Converter ()
@@ -103,7 +103,7 @@ containsLeftTypeVars (IR.TypeApp _ (IR.TypeVar srcSpan varId) _) =
     $  Message srcSpan Error
     $  "Type variable "
     ++ varId
-    ++ " occurs on right-hand"
+    ++ " occurs on left-hand"
     ++ " side of type application"
 containsLeftTypeVars (IR.TypeApp _ lhs _) = do
   containsLeftTypeVars lhs

--- a/src/lib/FreeC/Pass/KindInferencePass.hs
+++ b/src/lib/FreeC/Pass/KindInferencePass.hs
@@ -105,8 +105,9 @@ containsLeftTypeVars (IR.TypeApp _ (IR.TypeVar srcSpan varId) _) =
     ++ varId
     ++ " occurs on left-hand"
     ++ " side of type application"
-containsLeftTypeVars (IR.TypeApp _ lhs _) = do
+containsLeftTypeVars (IR.TypeApp _ lhs rhs) = do
   containsLeftTypeVars lhs
+  containsLeftTypeVars rhs
 containsLeftTypeVars (IR.FuncType _ lhs rhs) = do
   containsLeftTypeVars lhs
   containsLeftTypeVars rhs

--- a/src/lib/FreeC/Pass/KindInferencePass.hs
+++ b/src/lib/FreeC/Pass/KindInferencePass.hs
@@ -1,20 +1,103 @@
 module Freec.Pass.KindInferencePass
-    (
-    ) where
+  ()
+where
 
-import qualified FreeC.IR.Syntax as IR
+import qualified FreeC.IR.Syntax               as IR
 import           FreeC.Monad.Converter
 import           FreeC.Monad.Reporter
 import           FreeC.Pass
 import           FreeC.Pretty
 
 kindInferencePass :: Pass IR.Module
-kindInferencePass = undefined
+kindInferencePass (Module _ _ _ typeDecls typeSigs  _ funcDecls ) = do
+  checkTypeDecls typeDecls
+  checkTypeSigs typeSigs
+  checkFuncDecls funcDecls
+
+checkTypeDecls :: Monad m => m IR.TypeDecl -> Converter ()
+checkTypeDecls typeDecls = mapM_ checkTypeDecl typeDecls
+
+checkTypeSigs :: Monad m => m IR.TypeSig -> Converter ()
+checkTypeSigs typeSigs = mapM_ checkTypeSig typeSigs
+
+checkFuncDecls :: Monad m => m IR.FuncDecl -> Converter ()
+checkFuncDecls funcDecls = mapM_ checkFuncDecl funcDecls
+
+checkTypes :: Monad m => m IR.Type -> Converter ()
+checkTypes types = mapM_ containsLeftTypeVars types
+
+checkTypeDecl :: IR.TypeDecl -> Converter ()
+checkTypeDecl (DataDecl _ _ _ conDecls) = mapM_ checkConDecl conDecls
+checkTypeDecl (TypeSynDecl _ _ _ typ) = containsLeftTypeVars typ
+
+checkConDecl :: IR.ConDecl -> Converter ()
+checkConDecl (ConDecl _ _ types) = mapM_ containsLeftTypeVars types
+
+checkTypeSig :: IR.TypeSig -> Converter ()
+checkTypeSig (TypeSig _ _ typeSchema) = checkTypeSchema typeSchema
+
+checkTypeSchema :: IR.TypeSchema -> Converter ()
+checkTypeSchema (TypeSchema _ _ typ) = containsLeftTypeVars typ
+
+checkFuncDecl :: IR.FuncDecl -> Converter ()
+checkFuncDecl (_ _ _ varPats retType rhs) = do
+  checkVarPats varPats
+  checkTypes retType
+  checkExpr rhs
+  return ()
+
+checkExpr :: IR.Expr -> Converter ()
+checkExpr (Con _ _ typeSchema) = mapM_ checkTypeSchema typeSchema
+checkExpr (Var _ _ typeSchema) = mapM_ checkTypeSchema typeSchema
+checkExpr (App _ lhs rhs typeSchema) = do
+  checkExpr lhs
+  checkExpr rhs
+  mapM_ checkTypeSchema typeSchema
+  return ()
+checkExpr (TypeAppExpr _ lhs rhs typeSchema) = do
+  checkExpr lhs
+  containsLeftTypeVars rhs
+  mapM_ checkTypeSchema typeSchema
+  return ()
+checkExpr (If _ cond thenExp elseExp typeSchema) = do
+  checkExpr cond
+  checkExpr thenExp
+  checkExpr elseExp
+  mapM_ checkTypeSchema typeSchema
+  return ()
+checkExpr (Case _ scrutinee alts typeSchema) = do
+  checkExpr scrutinee
+  checkAlts alts
+  mapM_ checkTypeSchema typeSchema
+  return ()
+checkExpr (Undefined _ typeSchema) = mapM_ checkTypeSchema typeSchema
+checkExpr (ErrorExpr _ _ typeSchema) = mapM_ checkTypeSchema typeSchema
+checkExpr (IntLiteral _ _ typeSchema) = mapM_ checkTypeSchema typeSchema
+checkExpr (Lambda _ args rhs typeSchema) = do
+  checkVarPats args
+  checkExpr rhs
+  mapM_ checkTypeSchema typeSchema
+  return ()
+
+checkVarPats :: Monad m => m IR.VarPat -> Converter ()
+checkVarPats varPats = mapM_ checkVarPat varPats
+
+checkVarPat :: VarPat -> Converter ()
+checkVarPat (VarPat _ _ typ) = checkTypes typ
+
 
 containsLeftTypeVars :: IR.Type -> Converter ()
-containsLeftTypeVars (TypeVar _ _)               = return ()
-containsLeftTypeVars (TypeCon _ _)               = return ()
-containsLeftTypeVars (TypeApp _ (TypeVar _ _) _) = reportLeftVarError
-containsLeftTypeVars (TypeApp _ lhs _)           = containsLeftTypeVars lhs
-containsLeftTypeVars (FuncType _ lhs rhs)        = containsLeftTypeVars lhs ||
-                                                   containsLeftTypeVars rhs
+containsLeftTypeVars (TypeVar _ _) = return ()
+containsLeftTypeVars (TypeCon _ _) = return ()
+containsLeftTypeVars (TypeApp _ (TypeVar srcSpan varId) _) =
+  reportFatal
+    $  Message srcSpan Error
+    $  "Type variable "
+    ++ varid
+    ++ " occurs on right-hand"
+    ++ " side of type application"
+containsLeftTypeVars (TypeApp _ lhs _) = do
+  containsLeftTypeVars lhs
+containsLeftTypeVars (FuncType _ lhs rhs) = do
+  containsLeftTypeVars lhs
+  containsLeftTypeVars rhs

--- a/src/lib/FreeC/Pipeline.hs
+++ b/src/lib/FreeC/Pipeline.hs
@@ -30,8 +30,8 @@ pipeline =
   , qualifierPass
   , resolverPass
   , importPass
-  , kindInferencePass
   , dependencyAnalysisPass [defineTypeDeclsPass]
+  , kindInferencePass
   , typeSignaturePass
   , dependencyAnalysisPass
     [typeInferencePass, defineFuncDeclsPass, partialityAnalysisPass]

--- a/src/lib/FreeC/Pipeline.hs
+++ b/src/lib/FreeC/Pipeline.hs
@@ -14,6 +14,7 @@ import           FreeC.Pass.EtaConversionPass
 import           FreeC.Pass.ExportPass
 import           FreeC.Pass.ImplicitPreludePass
 import           FreeC.Pass.ImportPass
+import           FreeC.Pass.KindInferencePass
 import           FreeC.Pass.PartialityAnalysisPass
 import           FreeC.Pass.TypeSignaturePass
 import           FreeC.Pass.TypeInferencePass
@@ -29,6 +30,7 @@ pipeline =
   , qualifierPass
   , resolverPass
   , importPass
+  , kindInferencePass
   , dependencyAnalysisPass [defineTypeDeclsPass]
   , typeSignaturePass
   , dependencyAnalysisPass

--- a/src/lib/FreeC/Pipeline.hs
+++ b/src/lib/FreeC/Pipeline.hs
@@ -14,7 +14,7 @@ import           FreeC.Pass.EtaConversionPass
 import           FreeC.Pass.ExportPass
 import           FreeC.Pass.ImplicitPreludePass
 import           FreeC.Pass.ImportPass
-import           FreeC.Pass.KindInferencePass
+import           FreeC.Pass.KindCheckPass
 import           FreeC.Pass.PartialityAnalysisPass
 import           FreeC.Pass.TypeSignaturePass
 import           FreeC.Pass.TypeInferencePass
@@ -31,7 +31,7 @@ pipeline =
   , resolverPass
   , importPass
   , dependencyAnalysisPass [defineTypeDeclsPass]
-  , kindInferencePass
+  , kindCheckPass
   , typeSignaturePass
   , dependencyAnalysisPass
     [typeInferencePass, defineFuncDeclsPass, partialityAnalysisPass]

--- a/src/test/FreeC/Pass/KindCheckPassTests.hs
+++ b/src/test/FreeC/Pass/KindCheckPassTests.hs
@@ -1,0 +1,43 @@
+module FreeC.Pass.KindCheckPassTests where
+
+import           Test.Hspec
+
+import           FreeC.Monad.Class.Testable
+import           FreeC.Pass.KindCheckPass
+import           FreeC.Test.Environment
+import           FreeC.Test.Parser
+
+testKindCheckPass :: Spec
+testKindCheckPass = describe "FreeC.Pass.KindCheckPassTests" $ do
+  testValidTypes
+  testNotValidTypes
+
+testValidTypes :: Spec
+testValidTypes = context "valid types" $ do
+  it "should accept a single type variable" $ do
+    input <- expectParseTestType "a"
+    shouldSucceed $ do
+      _ <- defineTestTypeVar "a"
+      checkType input
+
+testNotValidTypes :: Spec
+testNotValidTypes = context "not valid types" $ do
+  it "should not accept type variable application" $ do
+    input <- expectParseTestType "m a"
+    shouldFail $ do
+      _ <- defineTestTypeVar "m"
+      _ <- defineTestTypeVar "a"
+      checkType input
+  it "should not accept underapplied applied type constructors" $ do
+    input <- expectParseTestType "State Int"
+    shouldFail $ do
+      _ <- defineTestTypeCon "State" 2
+      _ <- defineTestTypeCon "Int" 0
+      checkType input
+  it "should not accept underapplied applied type synonyms" $ do
+    input <- expectParseTestType "State Int"
+    shouldFail $ do
+      _ <- defineTestTypeSyn "State" ["s", "a"] "s -> (,) s a"
+      _ <- defineTestTypeCon "Int" 0
+      _ <- defineTestTypeCon "(,)" 2
+      checkType input

--- a/src/test/FreeC/Pass/KindCheckPassTests.hs
+++ b/src/test/FreeC/Pass/KindCheckPassTests.hs
@@ -26,26 +26,26 @@ testValidTypes = context "valid types" $ do
   it "should accept constant type constructors" $ do
     input <- expectParseTestType "()"
     shouldSucceed $ do
-      _ <- defineTestTypeCon "()" 0
+      _ <- defineTestTypeCon "()" 0 ["()"]
       checkType input
   it "should accept constant type synonyms" $ do
     input <- expectParseTestType "Name"
     shouldSucceed $ do
       _ <- defineTestTypeSyn "Name" [] "String"
-      _ <- defineTestTypeCon "String" 0
+      _ <- defineTestTypeCon "String" 0 []
       checkType input
   it "should accept fully applied type constructors" $ do
     input <- expectParseTestType "State Int Int"
     shouldSucceed $ do
-      _ <- defineTestTypeCon "State" 2
-      _ <- defineTestTypeCon "Int" 0
+      _ <- defineTestTypeCon "State" 2 []
+      _ <- defineTestTypeCon "Int" 0 []
       checkType input
   it "should accept fully applied type synonyms" $ do
     input <- expectParseTestType "State Int Int"
     shouldSucceed $ do
       _ <- defineTestTypeSyn "State" ["s", "a"] "s -> (,) s a"
-      _ <- defineTestTypeCon "Int" 0
-      _ <- defineTestTypeCon "(,)" 2
+      _ <- defineTestTypeCon "Int" 0 []
+      _ <- defineTestTypeCon "(,)" 2 []
       checkType input
   it "should accept a single type variable in function type signatures" $ do
     input <- expectParseTestModule
@@ -107,28 +107,28 @@ testNotValidTypes = context "not valid types" $ do
   it "should not accept underapplied type constructors" $ do
     input <- expectParseTestType "State Int"
     shouldFail $ do
-      _ <- defineTestTypeCon "State" 2
-      _ <- defineTestTypeCon "Int" 0
+      _ <- defineTestTypeCon "State" 2 []
+      _ <- defineTestTypeCon "Int" 0 []
       checkType input
   it "should not accept underapplied type synonyms" $ do
     input <- expectParseTestType "State Int"
     shouldFail $ do
       _ <- defineTestTypeSyn "State" ["s", "a"] "s -> (,) s a"
-      _ <- defineTestTypeCon "Int" 0
-      _ <- defineTestTypeCon "(,)" 2
+      _ <- defineTestTypeCon "Int" 0 []
+      _ <- defineTestTypeCon "(,)" 2 []
       checkType input
   it "should not accept overapplied type constructors" $ do
     input <- expectParseTestType "State Int Int Int"
     shouldFail $ do
-      _ <- defineTestTypeCon "State" 2
-      _ <- defineTestTypeCon "Int" 0
+      _ <- defineTestTypeCon "State" 2 []
+      _ <- defineTestTypeCon "Int" 0 []
       checkType input
   it "should not accept overapplied type synonyms" $ do
     input <- expectParseTestType "State Int Int Int"
     shouldFail $ do
       _ <- defineTestTypeSyn "State" ["s", "a"] "s -> (,) s a"
-      _ <- defineTestTypeCon "Int" 0
-      _ <- defineTestTypeCon "(,)" 2
+      _ <- defineTestTypeCon "Int" 0 []
+      _ <- defineTestTypeCon "(,)" 2 []
       checkType input
   it "should not accept type variable applications in function type signatures"
     $ do

--- a/src/test/FreeC/Pass/KindCheckPassTests.hs
+++ b/src/test/FreeC/Pass/KindCheckPassTests.hs
@@ -1,3 +1,5 @@
+-- | This module contains tests for "FreeC.Pass.KindCheckPass".
+
 module FreeC.Pass.KindCheckPassTests where
 
 import           Test.Hspec

--- a/src/test/FreeC/Pass/KindCheckPassTests.hs
+++ b/src/test/FreeC/Pass/KindCheckPassTests.hs
@@ -19,25 +19,164 @@ testValidTypes = context "valid types" $ do
     shouldSucceed $ do
       _ <- defineTestTypeVar "a"
       checkType input
+  it "should accept constant type constructors" $ do
+    input <- expectParseTestType "()"
+    shouldSucceed $ do
+      _ <- defineTestTypeCon "()" 0
+      checkType input
+  it "should accept constant type synonyms" $ do
+    input <- expectParseTestType "Name"
+    shouldSucceed $ do
+      _ <- defineTestTypeSyn "Name" [] "String"
+      _ <- defineTestTypeCon "String" 0
+      checkType input
+  it "should accept fully applied type constructors" $ do
+    input <- expectParseTestType "State Int Int"
+    shouldSucceed $ do
+      _ <- defineTestTypeCon "State" 2
+      _ <- defineTestTypeCon "Int" 0
+      checkType input
+  it "should accept fully applied type synonyms" $ do
+    input <- expectParseTestType "State Int Int"
+    shouldSucceed $ do
+      _ <- defineTestTypeSyn "State" ["s", "a"] "s -> (,) s a"
+      _ <- defineTestTypeCon "Int" 0
+      _ <- defineTestTypeCon "(,)" 2
+      checkType input
+  it "should accept a single type variable in function type signatures" $ do
+    input <- expectParseTestModule
+      ["module M where", "f :: forall a. a -> a;", "f x = x;"]
+    shouldSucceed $ do
+      _ <- defineTestTypeVar "a"
+      _ <- defineTestVar "x"
+      _ <- defineTestFunc "f" 1 "forall a. a -> a"
+      kindCheckPass input
+  it "should accept a single type variable in function return types" $ do
+    input <- expectParseTestModule ["module M where", "f x :: a = x;"]
+    shouldSucceed $ do
+      _ <- defineTestTypeVar "a"
+      _ <- defineTestVar "x"
+      _ <- defineTestFunc "f" 1 "forall a. a -> a"
+      kindCheckPass input
+  it "should accept a single type variable in type annotated function arguments"
+    $ do
+        input <- expectParseTestModule ["module M where", "f (x :: a) = x;"]
+        shouldSucceed $ do
+          _ <- defineTestTypeVar "a"
+          _ <- defineTestVar "x"
+          _ <- defineTestFunc "f" 1 "forall a. a -> a"
+          kindCheckPass input
+  it "should accept a single type variable in type annotated variables" $ do
+    input <- expectParseTestModule ["module M where", "f x = x :: a;"]
+    shouldSucceed $ do
+      _ <- defineTestTypeVar "a"
+      _ <- defineTestVar "x"
+      _ <- defineTestFunc "f" 1 "forall a. a -> a"
+      kindCheckPass input
+  it
+      "should accept a single type variable in type annotated case expression variables"
+    $ do
+        input <- expectParseTestModule
+          ["module M where", "f x = case x of {C (y :: b) -> y};"]
+        shouldSucceed $ do
+          _ <- defineTestTypeVar "a"
+          _ <- defineTestTypeVar "b"
+          _ <- defineTestVar "x"
+          _ <- defineTestVar "y"
+          _ <- defineTestCon "C" 0 "forall a. a"
+          _ <- defineTestFunc "f" 1 "forall a b. a -> b"
+          kindCheckPass input
 
 testNotValidTypes :: Spec
 testNotValidTypes = context "not valid types" $ do
-  it "should not accept type variable application" $ do
+  it "should not accept type variable applications" $ do
     input <- expectParseTestType "m a"
     shouldFail $ do
       _ <- defineTestTypeVar "m"
       _ <- defineTestTypeVar "a"
       checkType input
-  it "should not accept underapplied applied type constructors" $ do
+  it "should not accept overapplied function application" $ do
+    input <- expectParseTestType "(a -> b) c"
+    shouldFail $ do
+      _ <- defineTestTypeVar "a"
+      _ <- defineTestTypeVar "b"
+      _ <- defineTestTypeVar "c"
+      checkType input
+  it "should not accept underapplied type constructors" $ do
     input <- expectParseTestType "State Int"
     shouldFail $ do
       _ <- defineTestTypeCon "State" 2
       _ <- defineTestTypeCon "Int" 0
       checkType input
-  it "should not accept underapplied applied type synonyms" $ do
+  it "should not accept underapplied type synonyms" $ do
     input <- expectParseTestType "State Int"
     shouldFail $ do
       _ <- defineTestTypeSyn "State" ["s", "a"] "s -> (,) s a"
       _ <- defineTestTypeCon "Int" 0
       _ <- defineTestTypeCon "(,)" 2
       checkType input
+  it "should not accept overapplied type constructors" $ do
+    input <- expectParseTestType "State Int Int Int"
+    shouldFail $ do
+      _ <- defineTestTypeCon "State" 2
+      _ <- defineTestTypeCon "Int" 0
+      checkType input
+  it "should not accept overapplied type synonyms" $ do
+    input <- expectParseTestType "State Int Int Int"
+    shouldFail $ do
+      _ <- defineTestTypeSyn "State" ["s", "a"] "s -> (,) s a"
+      _ <- defineTestTypeCon "Int" 0
+      _ <- defineTestTypeCon "(,)" 2
+      checkType input
+  it "should not accept type variable applications in function type signatures"
+    $ do
+        input <- expectParseTestModule
+          ["module M where", "f :: forall m a. m a -> m a;", "f x = x;"]
+        shouldFail $ do
+          _ <- defineTestTypeVar "m"
+          _ <- defineTestTypeVar "a"
+          _ <- defineTestVar "x"
+          _ <- defineTestFunc "f" 1 "forall a. m a -> m a"
+          kindCheckPass input
+  it "should not accept type variable applications in function return types"
+    $ do
+        input <- expectParseTestModule ["module M where", "f x :: m a = x;"]
+        shouldFail $ do
+          _ <- defineTestTypeVar "m"
+          _ <- defineTestTypeVar "a"
+          _ <- defineTestVar "x"
+          _ <- defineTestFunc "f" 1 "forall m a. m a -> m a"
+          kindCheckPass input
+  it
+      "should not accept type variable applications in type annotated function arguments"
+    $ do
+        input <- expectParseTestModule ["module M where", "f (x :: m a) = x;"]
+        shouldFail $ do
+          _ <- defineTestTypeVar "m"
+          _ <- defineTestTypeVar "a"
+          _ <- defineTestVar "x"
+          _ <- defineTestFunc "f" 1 "forall m a. m a -> m a"
+          kindCheckPass input
+  it "should not accept type variable applications in type annotated variables"
+    $ do
+        input <- expectParseTestModule ["module M where", "f x = x :: m a;"]
+        shouldFail $ do
+          _ <- defineTestTypeVar "m"
+          _ <- defineTestTypeVar "a"
+          _ <- defineTestVar "x"
+          _ <- defineTestFunc "f" 1 "forall m a. m a -> m a"
+          kindCheckPass input
+  it
+      "should not accept type variable applications in type annotated case expression variables"
+    $ do
+        input <- expectParseTestModule
+          ["module M where", "f x = case x of {C (y :: m b) -> y};"]
+        shouldFail $ do
+          _ <- defineTestTypeVar "m"
+          _ <- defineTestTypeVar "a"
+          _ <- defineTestTypeVar "b"
+          _ <- defineTestVar "x"
+          _ <- defineTestVar "y"
+          _ <- defineTestCon "C" 0 "forall a. a"
+          _ <- defineTestFunc "f" 1 "forall m a b. a -> m b"
+          kindCheckPass input

--- a/src/test/FreeC/Pass/KindCheckPassTests.hs
+++ b/src/test/FreeC/Pass/KindCheckPassTests.hs
@@ -7,11 +7,13 @@ import           FreeC.Pass.KindCheckPass
 import           FreeC.Test.Environment
 import           FreeC.Test.Parser
 
+-- | Test group for 'kindCheckPass' tests.
 testKindCheckPass :: Spec
 testKindCheckPass = describe "FreeC.Pass.KindCheckPassTests" $ do
   testValidTypes
   testNotValidTypes
 
+-- | Test group for tests that check if 'kindCheckPass' accepts valid types.
 testValidTypes :: Spec
 testValidTypes = context "valid types" $ do
   it "should accept a single type variable" $ do
@@ -79,14 +81,14 @@ testValidTypes = context "valid types" $ do
         input <- expectParseTestModule
           ["module M where", "f x = case x of {C (y :: b) -> y};"]
         shouldSucceed $ do
-          _ <- defineTestTypeVar "a"
-          _ <- defineTestTypeVar "b"
-          _ <- defineTestVar "x"
-          _ <- defineTestVar "y"
+          mapM_ defineTestTypeVar ["a", "b"]
+          mapM_ defineTestVar     ["x", "y"]
           _ <- defineTestCon "C" 0 "forall a. a"
           _ <- defineTestFunc "f" 1 "forall a b. a -> b"
           kindCheckPass input
 
+-- | Test group for tests that check if 'kindCheckPass' rejects not valid
+--   types.
 testNotValidTypes :: Spec
 testNotValidTypes = context "not valid types" $ do
   it "should not accept type variable applications" $ do
@@ -98,9 +100,7 @@ testNotValidTypes = context "not valid types" $ do
   it "should not accept overapplied function application" $ do
     input <- expectParseTestType "(a -> b) c"
     shouldFail $ do
-      _ <- defineTestTypeVar "a"
-      _ <- defineTestTypeVar "b"
-      _ <- defineTestTypeVar "c"
+      mapM_ defineTestTypeVar ["a", "b", "c"]
       checkType input
   it "should not accept underapplied type constructors" $ do
     input <- expectParseTestType "State Int"
@@ -133,8 +133,7 @@ testNotValidTypes = context "not valid types" $ do
         input <- expectParseTestModule
           ["module M where", "f :: forall m a. m a -> m a;", "f x = x;"]
         shouldFail $ do
-          _ <- defineTestTypeVar "m"
-          _ <- defineTestTypeVar "a"
+          mapM_ defineTestTypeVar ["m", "a"]
           _ <- defineTestVar "x"
           _ <- defineTestFunc "f" 1 "forall a. m a -> m a"
           kindCheckPass input
@@ -142,8 +141,7 @@ testNotValidTypes = context "not valid types" $ do
     $ do
         input <- expectParseTestModule ["module M where", "f x :: m a = x;"]
         shouldFail $ do
-          _ <- defineTestTypeVar "m"
-          _ <- defineTestTypeVar "a"
+          mapM_ defineTestTypeVar ["m", "a"]
           _ <- defineTestVar "x"
           _ <- defineTestFunc "f" 1 "forall m a. m a -> m a"
           kindCheckPass input
@@ -152,8 +150,7 @@ testNotValidTypes = context "not valid types" $ do
     $ do
         input <- expectParseTestModule ["module M where", "f (x :: m a) = x;"]
         shouldFail $ do
-          _ <- defineTestTypeVar "m"
-          _ <- defineTestTypeVar "a"
+          mapM_ defineTestTypeVar ["m", "a"]
           _ <- defineTestVar "x"
           _ <- defineTestFunc "f" 1 "forall m a. m a -> m a"
           kindCheckPass input
@@ -161,8 +158,7 @@ testNotValidTypes = context "not valid types" $ do
     $ do
         input <- expectParseTestModule ["module M where", "f x = x :: m a;"]
         shouldFail $ do
-          _ <- defineTestTypeVar "m"
-          _ <- defineTestTypeVar "a"
+          mapM_ defineTestTypeVar ["m", "a"]
           _ <- defineTestVar "x"
           _ <- defineTestFunc "f" 1 "forall m a. m a -> m a"
           kindCheckPass input
@@ -172,11 +168,8 @@ testNotValidTypes = context "not valid types" $ do
         input <- expectParseTestModule
           ["module M where", "f x = case x of {C (y :: m b) -> y};"]
         shouldFail $ do
-          _ <- defineTestTypeVar "m"
-          _ <- defineTestTypeVar "a"
-          _ <- defineTestTypeVar "b"
-          _ <- defineTestVar "x"
-          _ <- defineTestVar "y"
+          mapM_ defineTestTypeVar ["m", "a", "b"]
+          mapM_ defineTestVar     ["x", "y"]
           _ <- defineTestCon "C" 0 "forall a. a"
           _ <- defineTestFunc "f" 1 "forall m a b. a -> m b"
           kindCheckPass input

--- a/src/test/FreeC/PipelineTests.hs
+++ b/src/test/FreeC/PipelineTests.hs
@@ -9,6 +9,7 @@ where
 import           Test.Hspec
 
 import           FreeC.Pass.EtaConversionPassTests
+import           FreeC.Pass.KindCheckPassTests
 import           FreeC.Pass.PartialityAnalysisPassTests
 import           FreeC.Pass.ResolverPassTests
 import           FreeC.Pass.TypeInferencePassTests
@@ -17,6 +18,7 @@ import           FreeC.Pass.TypeInferencePassTests
 testPipeline :: Spec
 testPipeline = do
   testEtaConversionPass
+  testKindCheckPass
   testPartialityAnalysisPass
   testResolverPass
   testTypeInferencePass


### PR DESCRIPTION
Add a new pass that checks whether type expressions do not have type variables as well as function types on the left-hand side of type expressions.
Additionally, this pass checks whether all type constructors are applied to the correct number of arguments.

Closes #22 