### PR TITLE
Fix compilation failures for `undefined` and `error`

### DIFF
--- a/src/lib/FreeC/Backend/Coq/Converter/Expr.hs
+++ b/src/lib/FreeC/Backend/Coq/Converter/Expr.hs
@@ -41,7 +41,7 @@ convertExpr' :: IR.Expr -> [IR.Type] -> [IR.Expr] -> Converter Coq.Term
 
 -- Constructors.
 --
--- Partially applied constructors are not evaluated in Haskell and therefor
+-- Partially applied constructors are not evaluated in Haskell and therefore
 -- cannot be @⊥@. The translated type of a constructor @C : τ₀ -> … -> τₙ@ is
 -- @c : τ₀' -> … -> τₙ*@ instead of @m(τ₀' -> m(τ₁' -> m(… -> τₙ')))@.
 --

--- a/src/lib/FreeC/Backend/Coq/Converter/Expr.hs
+++ b/src/lib/FreeC/Backend/Coq/Converter/Expr.hs
@@ -216,7 +216,7 @@ convertExpr' (IR.ErrorExpr srcSpan msg _) typeArgs args = do
   args'     <- mapM convertExpr args
   let partialArg = [Coq.Qualid (fst Coq.Base.partialArg)]
       callee     = genericApply Coq.Base.partialError partialArg typeArgs' []
-  generateApplyN (1 :: Int)
+  generateApplyN 1
                  callee
                  (Coq.InScope (Coq.string msg) Coq.Base.stringScope : args')
 

--- a/src/lib/FreeC/Backend/Coq/Converter/Expr.hs
+++ b/src/lib/FreeC/Backend/Coq/Converter/Expr.hs
@@ -218,7 +218,7 @@ convertExpr' (IR.ErrorExpr srcSpan msg _) typeArgs args = do
       callee     = genericApply Coq.Base.partialError partialArg typeArgs' []
   generateApplyN (1 :: Int)
                  callee
-                 ((Coq.InScope (Coq.string msg) Coq.Base.stringScope) : args')
+                 (Coq.InScope (Coq.string msg) Coq.Base.stringScope : args')
 
 -- Integer literals.
 convertExpr' (IR.IntLiteral _ value _) [] [] = do

--- a/src/test/FreeC/Backend/Coq/Converter/ExprTests.hs
+++ b/src/test/FreeC/Backend/Coq/Converter/ExprTests.hs
@@ -364,7 +364,8 @@ testConvertError :: Spec
 testConvertError = context "error expressions" $ do
   it "translates error expressions correctly" $ shouldSucceedWith $ do
     "a" <- defineTestTypeVar "a"
-    shouldConvertExprTo "error @a \"message\"" "@error Shape Pos P a \"message\"%string"
+    shouldConvertExprTo "error @a \"message\""
+                        "@error Shape Pos P a \"message\"%string"
 
   it "translates error expressions applied to arguments correctly"
     $ shouldSucceedWith

--- a/src/test/FreeC/Backend/Coq/Converter/ExprTests.hs
+++ b/src/test/FreeC/Backend/Coq/Converter/ExprTests.hs
@@ -44,6 +44,7 @@ testConvertExpr = describe "FreeC.Backend.Coq.Converter.Expr.convertExpr" $ do
   testConvertTypeAppExprs
   testConvertInteger
   testConvertUndefined
+  testConvertError
 
 -------------------------------------------------------------------------------
 -- Constructor applications                                                  --
@@ -355,5 +356,27 @@ testConvertUndefined = context "undefined expressions" $ do
         shouldConvertExprTo "undefined @(a->b->c) x y"
           $  "(@undefined Shape Pos P (Free Shape Pos a ->"
           ++ " Free Shape Pos (Free Shape Pos b -> Free Shape Pos c))"
+          ++ " >>= (fun f_0 => f_0 x))"
+          ++ " >>= (fun f_0 => f_0 y)"
+
+-- | Test group for translation of undefined expressions.
+testConvertError :: Spec
+testConvertError = context "error expressions" $ do
+  it "translates error expressions correctly" $ shouldSucceedWith $ do
+    "a" <- defineTestTypeVar "a"
+    shouldConvertExprTo "error @a \"message\"" "@error Shape Pos P a \"message\"%string"
+
+  it "translates error expressions applied to arguments correctly"
+    $ shouldSucceedWith
+    $ do
+        "a" <- defineTestTypeVar "a"
+        "b" <- defineTestTypeVar "b"
+        "c" <- defineTestTypeVar "c"
+        "x" <- defineTestVar "x"
+        "y" <- defineTestVar "y"
+        shouldConvertExprTo "error @(a->b->c) \"message\" x y"
+          $  "(@error Shape Pos P (Free Shape Pos a ->"
+          ++ " Free Shape Pos (Free Shape Pos b -> Free Shape Pos c))"
+          ++ " \"message\"%string"
           ++ " >>= (fun f_0 => f_0 x))"
           ++ " >>= (fun f_0 => f_0 y)"

--- a/src/test/FreeC/Backend/Coq/Converter/ExprTests.hs
+++ b/src/test/FreeC/Backend/Coq/Converter/ExprTests.hs
@@ -43,6 +43,7 @@ testConvertExpr = describe "FreeC.Backend.Coq.Converter.Expr.convertExpr" $ do
   testConvertExprTypeAnnotations
   testConvertTypeAppExprs
   testConvertInteger
+  testConvertUndefined
 
 -------------------------------------------------------------------------------
 -- Constructor applications                                                  --
@@ -334,3 +335,25 @@ testConvertInteger = context "integer expressions" $ do
   it "translates negative decimal integer literals correctly"
     $ shouldSucceedWith
     $ shouldConvertExprTo "-42" "pure (- 42)%Z"
+
+
+-- | Test group for translation of undefined expressions.
+testConvertUndefined :: Spec
+testConvertUndefined = context "undefined expressions" $ do
+  it "translates undefined expressions correctly" $ shouldSucceedWith $ do
+    "a" <- defineTestTypeVar "a"
+    shouldConvertExprTo "undefined @a" "@undefined Shape Pos P a"
+
+  it "translates undefined expressions applied to arguments correctly"
+    $ shouldSucceedWith
+    $ do
+        "a" <- defineTestTypeVar "a"
+        "b" <- defineTestTypeVar "b"
+        "c" <- defineTestTypeVar "c"
+        "x" <- defineTestVar "x"
+        "y" <- defineTestVar "y"
+        shouldConvertExprTo "undefined @(a->b->c) x y"
+          $  "(@undefined Shape Pos P (Free Shape Pos a ->"
+          ++ " Free Shape Pos (Free Shape Pos b -> Free Shape Pos c))"
+          ++ " >>= (fun f_0 => f_0 x))"
+          ++ " >>= (fun f_0 => f_0 y)"


### PR DESCRIPTION
As described in #62, the Free Compiler suffers an internal error if `undefined` is applied to anything, because the compiler doesn't expect the type of `undefined` to be a function. The same behavior occurs with `error`. This pull request fixes both bugs and adds some test cases for them. Closes #62.