### PR TITLE
Fix typos in some modules (Block 8)

### DIFF
--- a/src/lib/FreeC/Backend/Coq/Converter/Arg.hs
+++ b/src/lib/FreeC/Backend/Coq/Converter/Arg.hs
@@ -24,10 +24,10 @@ import           FreeC.Monad.Converter
 --   binder @(a b : Type)@ because we assume all Haskell type variables to be
 --   of kind @*@.
 --
---   The first argument controlls whether the generated binders are explicit
+--   The first argument controls whether the generated binders are explicit
 --   (e.g. @(a : Type)@) or implicit (e.g. @{a : Type}@).
 convertTypeVarDecls
-  :: Coq.Explicitness -- ^ Whether to generate an explicit or implit binder.
+  :: Coq.Explicitness -- ^ Whether to generate an explicit or implicit binder.
   -> [IR.TypeVarDecl] -- ^ The type variable declarations.
   -> Converter [Coq.Binder]
 convertTypeVarDecls explicitness typeVarDecls
@@ -69,7 +69,7 @@ generateArgBinder ident' Nothing =
 generateArgBinder ident' (Just argType') =
   return (Coq.typedBinder' Coq.Explicit ident' argType')
 
--- | Converts the argument of an artifically generated function to an explicit
+-- | Converts the argument of an artificially generated function to an explicit
 --   Coq binder. A fresh Coq identifier is selected for the argument
 --   and returned together with the binder.
 convertAnonymousArg :: Maybe IR.Type -> Converter (Coq.Qualid, Coq.Binder)

--- a/src/lib/FreeC/Backend/Coq/Converter/Expr.hs
+++ b/src/lib/FreeC/Backend/Coq/Converter/Expr.hs
@@ -48,7 +48,7 @@ convertExpr' :: IR.Expr -> [IR.Type] -> [IR.Expr] -> Converter Coq.Term
 --
 -- Note that the return type is translated using * not ', because a constructor
 -- in Coq cannot return a wrapped value. A smart constructor @C@ is generated,
--- which wrapps the value of @c@. It is therefore sufficient to just convert
+-- which wraps the value of @c@. It is therefore sufficient to just convert
 -- and apply the arguments.
 convertExpr' (IR.Con srcSpan name _) typeArgs args = do
   qualid            <- lookupSmartIdentOrFail srcSpan name
@@ -240,7 +240,7 @@ convertExpr' expr (_ : _) _ =
 
 -- Application of an expression other than a function or constructor
 -- application. We use an as-pattern for @args@ such that we get a compile
--- time warning when a node is added to the AST that we do not conver above.
+-- time warning when a node is added to the AST that we do not cover above.
 convertExpr' expr [] args@(_ : _) = do
   expr' <- convertExpr' expr [] []
   args' <- mapM convertExpr args

--- a/src/lib/FreeC/Backend/Coq/Converter/Free.hs
+++ b/src/lib/FreeC/Backend/Coq/Converter/Free.hs
@@ -1,4 +1,4 @@
--- | This module contains auxilary functions that help to generate Coq code
+-- | This module contains auxiliary functions that help to generate Coq code
 --   that uses the @Free@ monad.
 
 module FreeC.Backend.Coq.Converter.Free where
@@ -18,7 +18,7 @@ import           FreeC.Monad.Converter
 
 -- | The declarations of type parameters for the @Free@ monad.
 --
---   The first argument controlls whether the generated binders are explicit
+--   The first argument controls whether the generated binders are explicit
 --   (e.g. @(Shape : Type)@) or implicit (e.g. @{Shape : Type}@).
 genericArgDecls :: Coq.Explicitness -> [Coq.Binder]
 genericArgDecls explicitness =
@@ -125,7 +125,7 @@ generateBind expr' defaultPrefix argType' generateRHS = localEnv $ do
   return
     (Coq.app (Coq.Qualid Coq.Base.freeBind) [expr', Coq.fun [x] [argType'] rhs])
  where
-  -- | Suggests a prefix for the fresh varibale the given expression
+  -- | Suggests a prefix for the fresh variable the given expression
   --   is bound to.
   suggestPrefixFor :: Coq.Term -> String
   suggestPrefixFor (Coq.Qualid qualid) =

--- a/src/lib/FreeC/Backend/Coq/Converter/Type.hs
+++ b/src/lib/FreeC/Backend/Coq/Converter/Type.hs
@@ -13,7 +13,7 @@ import           FreeC.Monad.Converter
 --
 --   [\(\tau^\dagger = Free\,Shape\,Pos\,\tau^*\)]
 --     A type \(\tau\) is converted by lifting it into the @Free@ monad and
---     recursivly converting the argument and return types of functions
+--     recursively converting the argument and return types of functions
 --     using 'convertType''.
 convertType :: IR.Type -> Converter Coq.Term
 convertType t = do
@@ -23,8 +23,8 @@ convertType t = do
 -- | Converts a Haskell type to Coq.
 --
 --   In contrast to 'convertType', the type itself is not lifted into the
---   @Free@ moand. Only the argument and return types of contained function
---   type constructors are lifted recursivly.
+--   @Free@ monad. Only the argument and return types of contained function
+--   type constructors are lifted recursively.
 --
 --   [\(\alpha^* = \alpha'\)]
 --     A type variable \(\alpha\) is translated by looking up the corresponding

--- a/src/lib/FreeC/Environment/Entry.hs
+++ b/src/lib/FreeC/Environment/Entry.hs
@@ -126,7 +126,7 @@ data EnvEntry
  deriving Show
 
 -------------------------------------------------------------------------------
--- Comparision                                                               --
+-- Comparison                                                               --
 -------------------------------------------------------------------------------
 
 -- | Entries are identified by their original name.

--- a/src/lib/FreeC/Environment/Fresh.hs
+++ b/src/lib/FreeC/Environment/Fresh.hs
@@ -50,7 +50,7 @@ freshFuncPrefix = "f"
 freshBoolPrefix :: String
 freshBoolPrefix = "cond"
 
--- | The prefix to use for aritifcially introduced type variables of kind @*@.
+-- | The prefix to use for artificially introduced type variables of kind @*@.
 freshTypeVarPrefix :: String
 freshTypeVarPrefix = "a"
 

--- a/src/lib/FreeC/Environment/LookupOrFail.hs
+++ b/src/lib/FreeC/Environment/LookupOrFail.hs
@@ -15,7 +15,7 @@ import           FreeC.Pretty
 
 -- | Looks up an entry of the environment with the given name or reports
 --   a fatal error message if the identifier has not been defined or the
---   name is ambigious.
+--   name is ambiguous.
 --
 --   If an error is reported, it points to the given source span.
 lookupEntryOrFail :: SrcSpan -> IR.Scope -> IR.QName -> Converter EnvEntry
@@ -45,7 +45,7 @@ lookupIdentOrFail srcSpan scope name = do
   return (entryIdent entry)
 
 -- | Looks up the Coq identifier of a smart constructor of the Haskell
---   data constructr with the given name or reports a fatal error message
+--   data constructor with the given name or reports a fatal error message
 --   if there is no such constructor.
 --
 --   If an error is reported, it points to the given source span.

--- a/src/lib/FreeC/Environment/ModuleInterface/Decoder.hs
+++ b/src/lib/FreeC/Environment/ModuleInterface/Decoder.hs
@@ -14,7 +14,7 @@
 --
 --   The TOML document is expected to contain four arrays of tables @types@,
 --   @type-synonyms@, @constructors@ and @functions@. Each table in these
---   arrays defines a data type, type synonym, constrcutor or function
+--   arrays defines a data type, type synonym, constructor or function
 --   respectively. The expected contents of each table is described below.
 --   In addition, the module interface file contains meta information in the
 --   top-level table.

--- a/src/lib/FreeC/Environment/Renamer.hs
+++ b/src/lib/FreeC/Environment/Renamer.hs
@@ -98,7 +98,7 @@ mustRenameIdent ident env =
 
 -- | Tests whether the given character is allowed in a Coq identifier.
 --
---   The Coq langauge specification also lists `unicode-id-part`s as allowed
+--   The Coq language specification also lists `unicode-id-part`s as allowed
 --   characters in identifiers and states that those include "non-exhaustively
 --   includes symbols for prime letters and subscripts". I have not yet been
 --   able to find a way to identify this category of unicode characters in
@@ -128,19 +128,19 @@ sanitizeIdent [] = "_"
 sanitizeIdent (firstChar : subsequentChars) =
   sanitizeFirstChar firstChar : map sanitizeChar subsequentChars
  where
-  -- | Replaces the given character with an underscope if it is not allowed
+  -- | Replaces the given character with an underscore if it is not allowed
   --   to occur in the first place of a Coq identifier.
   sanitizeFirstChar :: Char -> Char
   sanitizeFirstChar c | isAllowedFirstChar c = c
                       | otherwise            = '_'
 
-  -- | Replaces the given character with an underscope if it is not allowed
+  -- | Replaces the given character with an underscore if it is not allowed
   --   to occur in a Coq identifier.
   sanitizeChar :: Char -> Char
   sanitizeChar c | isAllowedChar c = c
                  | otherwise       = '_'
 
--- | Renames a Haskell identifier such that it can be savely used in Coq.
+-- | Renames a Haskell identifier such that it can be safely used in Coq.
 --
 --   If the identifier has no name conflict, it is return unchanged.
 --   If the identifier would cause a name conflict the smallest natural number


### PR DESCRIPTION
I ran a spellchecker on the following modules (Block 8) and fixed the typos it found.

```
   313 ./lib/FreeC/Environment.hs
   281 ./lib/FreeC/Environment/Renamer.hs
   216 ./lib/FreeC/Environment/Entry.hs
   146 ./lib/FreeC/Environment/Fresh.hs
    39 ./lib/FreeC/Environment/ModuleInterface.hs
   147 ./lib/FreeC/Environment/ModuleInterface/Encoder.hs
   280 ./lib/FreeC/Environment/ModuleInterface/Decoder.hs
    58 ./lib/FreeC/Environment/LookupOrFail.hs
    49 ./lib/FreeC/Backend/Coq/Pretty.hs
    27 ./lib/FreeC/Backend/Coq/Converter/FuncDecl.hs
   223 ./lib/FreeC/Backend/Coq/Converter/TypeDecl.hs
    58 ./lib/FreeC/Backend/Coq/Converter/Type.hs
   139 ./lib/FreeC/Backend/Coq/Converter/Free.hs
    80 ./lib/FreeC/Backend/Coq/Converter/Arg.hs
   135 ./lib/FreeC/Backend/Coq/Converter/Module.hs
   307 ./lib/FreeC/Backend/Coq/Converter/Expr.hs
```