### PR TITLE
Transition to `main` default branch

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -8,7 +8,7 @@ about: Create a report to help us improve
 <!--
   Have you read our Code of Conduct?
   By filing an issue, you are expected to comply with it, including treating everyone with respect:
-  https://github.com/FreeProving/guidelines/blob/master/CODE_OF_CONDUCT.md
+  https://github.com/FreeProving/guidelines/blob/main/CODE_OF_CONDUCT.md
 -->
 
 ### Description

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -8,7 +8,7 @@ about: Suggest an idea for this project
 <!--
   Have you read our Code of Conduct?
   By filing an issue, you are expected to comply with it, including treating everyone with respect:
-  https://github.com/FreeProving/guidelines/blob/master/CODE_OF_CONDUCT.md
+  https://github.com/FreeProving/guidelines/blob/main/CODE_OF_CONDUCT.md
 -->
 
 ## Description

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -6,9 +6,9 @@ name: CI Pipeline
 # or reopened. If just the README or documentation changes, the pipeline does
 # not have to run. It also runs when the workflow configuration changed itself.
 #
-# When such a pull request is merged the resulting `push` event on the master
+# When such a pull request is merged the resulting `push` event on the main
 # branch triggers another run of the CI pipeline. This is necessary because
-# there could be changes to the master branch that are not compatible with the
+# there could be changes to the main branch that are not compatible with the
 # pull request but don't prevent fast-forward merging.
 # Furthermore, the documentation is deployed to GitHub pages during the second
 # run of the CI pipeline.
@@ -32,7 +32,7 @@ on:
     - '.github/workflows/ci-pipeline.yml'
   push:
     branches:
-    - 'master'
+    - 'main'
     - 'dev-*'
     paths:
     - 'cabal.project'
@@ -294,7 +294,7 @@ jobs:
   # when forking the repository.
   #
   # This job only runs on `push` events and not on `pull_request` events.
-  # This limits the deployment effectively to the master branch (and maybe
+  # This limits the deployment effectively to the main branch (and maybe
   # tags in the future).
   #
   # **NEVER** commit the contents of the private key!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,10 @@
  - **Initial version**
 
 [`doc/ExperimentalFeatures/PatternMatchingCompilation.md`]:
-  https://github.com/FreeProving/free-compiler/blob/master/doc/ExperimentalFeatures/PatternMatchingCompilation.md
+  https://github.com/FreeProving/free-compiler/blob/main/doc/ExperimentalFeatures/PatternMatchingCompilation.md
   "Free Compiler Documentation — Pattern Matching Compilation"
 [`doc/CustomPragma/DecreasingArgumentPragma.md`]:
-  https://github.com/FreeProving/free-compiler/blob/master/doc/CustomPragma/DecreasingArgumentPragma.md
+  https://github.com/FreeProving/free-compiler/blob/main/doc/CustomPragma/DecreasingArgumentPragma.md
   "Free Compiler Documentation — Decreasing Argument Pragma"
 
 [tag/v0.1.0.0]:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,5 +4,5 @@ The Free Proving project and everyone participating in it is governed by our [Co
 By participating, you are expected to uphold this code.
 
 [CODE_OF_CONDUCT]:
-  https://github.com/FreeProving/guidelines/blob/master/CODE_OF_CONDUCT.md
+  https://github.com/FreeProving/guidelines/blob/main/CODE_OF_CONDUCT.md
   "Code of Conduct of the FreeProving project"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,5 +3,5 @@
 See the [contributing guidelines][] of the FreeProving project.
 
 [contributing guidelines]:
-  https://github.com/FreeProving/guidelines/blob/master/CONTRIBUTING.md
+  https://github.com/FreeProving/guidelines/blob/main/CONTRIBUTING.md
   "Contributing Guidelines of the FreeProving project"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Free Compiler
 
 <!-- Logo -->
-<img src="https://raw.githubusercontent.com/FreeProving/free-compiler/master/img/logo.png" width="350" style="max-width: 100%" align="right" alt="Logo" />
+<img src="https://raw.githubusercontent.com/FreeProving/free-compiler/main/img/logo.png" width="350" style="max-width: 100%" align="right" alt="Logo" />
 
 <!-- Badges -->
 ![CI Pipeline](https://github.com/FreeProving/free-compiler/workflows/CI%20Pipeline/badge.svg)
@@ -391,40 +391,40 @@ The Free Compiler is licensed under The 3-Clause BSD License.
 See the [LICENSE][freec/LICENSE] file for details.
 
 [doc]:
-  https://github.com/FreeProving/free-compiler/tree/master/doc
+  https://github.com/FreeProving/free-compiler/tree/main/doc
   "Free Compiler Documentation"
 [doc/ModuleInterfaceFileFormat.md]:
-  https://github.com/FreeProving/free-compiler/blob/master/doc/ModuleInterfaceFileFormat.md
+  https://github.com/FreeProving/free-compiler/blob/main/doc/ModuleInterfaceFileFormat.md
   "Free Compiler Documentation — Module Interface File Format"
 [doc/ExperimentalFeatures/PatternMatchingCompilation.md]:
-  https://github.com/FreeProving/free-compiler/blob/master/doc/ExperimentalFeatures/PatternMatchingCompilation.md
+  https://github.com/FreeProving/free-compiler/blob/main/doc/ExperimentalFeatures/PatternMatchingCompilation.md
   "Free Compiler Documentation — Pattern Matching Compilation"
 [doc/ProvingQuickCheckProperties.md]:
-  https://github.com/FreeProving/free-compiler/blob/master/doc/ProvingQuickCheckProperties.md
+  https://github.com/FreeProving/free-compiler/blob/main/doc/ProvingQuickCheckProperties.md
   "Free Compiler Documentation — Proving QuickCheck Properties"
 
 [freec/CHANGELOG]:
-  https://github.com/FreeProving/free-compiler/blob/master/CHANGELOG.md
+  https://github.com/FreeProving/free-compiler/blob/main/CHANGELOG.md
   "Free Compiler — Changelog"
 [freec/LICENSE]:
-  https://github.com/FreeProving/free-compiler/blob/master/LICENSE
+  https://github.com/FreeProving/free-compiler/blob/main/LICENSE
   "Free Compiler — The 3-Clause BSD License"
 
 [guidelines/CONTRIBUTING]:
-  https://github.com/FreeProving/guidelines/blob/master/CONTRIBUTING.md
+  https://github.com/FreeProving/guidelines/blob/main/CONTRIBUTING.md
   "Contributing Guidelines of the FreeProving project"
 [guidelines/CONTRIBUTING#the-ci-pipeline]:
-  https://github.com/FreeProving/guidelines/blob/master/CONTRIBUTING.md#the-ci-pipeline
+  https://github.com/FreeProving/guidelines/blob/main/CONTRIBUTING.md#the-ci-pipeline
   "Contributing Guidelines of the FreeProving project — The CI Pipeline"
 
 [gh-pages/haddock/exe]:
-  https://freeproving.github.io/free-compiler/docs/master/freec
+  https://freeproving.github.io/free-compiler/docs/main/freec
   "Free Compiler Command Line Interface Haddock Documentation"
 [gh-pages/haddock/lib]:
-  https://freeproving.github.io/free-compiler/docs/master
+  https://freeproving.github.io/free-compiler/docs/main
   "Free Compiler Haddock Documentation"
 [gh-pages/haddock/test]:
-  https://freeproving.github.io/free-compiler/docs/master/freec-unit-tests
+  https://freeproving.github.io/free-compiler/docs/main/freec-unit-tests
   "Free Compiler Test Suite Haddock Documentation"
 
 [package/haskell-src-transformations]:


### PR DESCRIPTION
## Description

We have decided to change the default branch of all repositories in the FreeProving organization from `master` to `main`. See FreeProving/guidelines#2 for more information.

## Tasks

The tasks below have to be completed for the transition to `main` as the new default branch. 

 - [x] Create a new branch `main` from the current `master`.
 - [x] Select `main` as the default branch in the repository settings on GitHub.
 - [x] Add branch protection rules for `main` in the repository settings on GitHub.
 - [x] Change the CI pipeline (if any) to run on pushes to `main`.
 - [x] If there are open pull requests, set their target branch to `main`.
 - [x] Update links to the `master` branch such that they point to `main` instead.
 - [x] Finally, delete the `master` branch. If the repository's `master` branch has been referenced in a published paper, keep the `master` branch, delete all files and commit a README that links to the new default branch.