### PR TITLE
Spell check haskell files

### DIFF
--- a/src/lib/FreeC/Frontend/IR/PragmaParser.hs
+++ b/src/lib/FreeC/Frontend/IR/PragmaParser.hs
@@ -71,7 +71,7 @@ parseCustomPragmas = mapMaybeM parseCustomPragma
 -- | Parses a pragma from the given comment.
 --
 --   Returns @Nothing@ if the given comment is not a pragma or an
---   unrecognised pragma.
+--   unrecognized pragma.
 parseCustomPragma :: IR.Comment -> Reporter (Maybe IR.Pragma)
 parseCustomPragma (IR.LineComment _ _) = return Nothing
 parseCustomPragma (IR.BlockComment srcSpan text) =

--- a/src/lib/FreeC/Monad/Class/Hoistable.hs
+++ b/src/lib/FreeC/Monad/Class/Hoistable.hs
@@ -8,7 +8,7 @@ import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.Maybe      ( MaybeT(..) )
 
 -- | Type class for monad transformers whose inner monad can be lifted from
---   'Identity' to some arbitry 'Monad'.
+--   'Identity' to some arbitrary 'Monad'.
 class MonadTrans t => Hoistable t where
   -- | Lifts the transformed identity monad to any transformed monad.
   hoist :: Monad m => t Identity a -> t m a

--- a/src/lib/FreeC/Monad/Reporter.hs
+++ b/src/lib/FreeC/Monad/Reporter.hs
@@ -331,7 +331,7 @@ prettyCodeBlock srcSpan
     let gutterWidth = length (show (srcSpanStartLine srcSpan)) + 2
     in  indent gutterWidth pipe
 
-  -- | Document that contains 'caret' signs to highligh the code in the
+  -- | Document that contains 'caret' signs to highlight the code in the
   --   first line that is covered by the source span.
   highlightDoc :: Doc
   highlightDoc = indent (srcSpanStartColumn srcSpan)
@@ -345,7 +345,7 @@ prettyCodeBlock srcSpan
     | otherwise
     = max 1 $ srcSpanEndColumn srcSpan - srcSpanStartColumn srcSpan
 
-  -- | Document added after the 'highlightDoc' if the source span coveres
+  -- | Document added after the 'highlightDoc' if the source span covers
   --   more than one line.
   ellipsisDoc :: Doc
   ellipsisDoc | isMultiLine = prettyString "..."

--- a/src/lib/FreeC/Pass/TypeInferencePass.hs
+++ b/src/lib/FreeC/Pass/TypeInferencePass.hs
@@ -466,7 +466,7 @@ inferFuncDeclTypes' funcDecls = withLocalState $ do
   --
   -- During the annotation of the function declaration, type equations were
   -- added. The system of type equations is solved by computing the most
-  -- general unificator (mgu).
+  -- general unifier (mgu).
   --
   -- The mgu is then applied to the annotated function declarations to
   -- replace the type variables (that act as place holders) by their
@@ -524,7 +524,7 @@ inferFuncDeclTypes' funcDecls = withLocalState $ do
 
   -- Abstract new vanishing type arguments.
   --
-  -- The instatiation of type schemas by 'applyFuncDeclVisibly' might
+  -- The instantiation of type schemas by 'applyFuncDeclVisibly' might
   -- have introduced new vanishing type arguments if a function with
   -- vanishing type arguments is applied that does not occur in the
   -- strongly connected component. Those additional type arguments
@@ -593,7 +593,7 @@ annotateExprWith' (IR.Con srcSpan conName _) resType = do
 -- are fresh type variables.
 -- In case of local variables or functions whose types are currently inferred,
 -- the type assumption of @x@ is not abstracted (i.e., @n = 0@).
--- Therfore a type equation that unifies the type the binder of @x@ has been
+-- Therefore a type equation that unifies the type the binder of @x@ has been
 -- annotated with and the given type @τ@ is simply added in this case.
 annotateExprWith' (IR.Var srcSpan varName _) resType = do
   addTypeEquationFor srcSpan varName resType
@@ -639,7 +639,7 @@ annotateExprWith' (IR.Case srcSpan scrutinee alts _) resType = do
       rhs' <- annotateExprWith rhs resType
       return (IR.Alt altSrcSpan conPat varPats' rhs')
 
--- Error terms are predefined polymorphic funtions. They can be annotated
+-- Error terms are predefined polymorphic functions. They can be annotated
 -- with the given result type directly.
 annotateExprWith' (IR.Undefined srcSpan _) resType =
   return (IR.Undefined srcSpan (makeExprType resType))
@@ -877,7 +877,7 @@ abstractVanishingTypeArgs funcDecls =
     | varName `Set.member` funcNames = (expr, internalTypeArgs)
     | otherwise                      = (expr, [])
 
-  -- Add new type arguments after exisiting visible type applications.
+  -- Add new type arguments after existing visible type applications.
   addInternalTypeArgsToExpr' funcNames (IR.TypeAppExpr srcSpan expr typeExpr exprType)
     = let (expr', typeArgs) = addInternalTypeArgsToExpr' funcNames expr
       in  (IR.TypeAppExpr srcSpan expr' typeExpr exprType, typeArgs)
@@ -923,7 +923,7 @@ abstractVanishingTypeArgs funcDecls =
 -- Solving type equations                                                    --
 -------------------------------------------------------------------------------
 
--- | Finds the most general unificator that satisfies all given type equations.
+-- | Finds the most general unifier that satisfies all given type equations.
 --
 --   The type equations are unified in reverse order in order to improve
 --   error messages. The list of type equations contains equations for


### PR DESCRIPTION
<!--
  Have you read our Code of Conduct?
  By filing an issue or pull request, you are expected to comply with it, including treating everyone with respect:
  https://github.com/FreeProving/guidelines/blob/main/CODE_OF_CONDUCT.md
-->

### Issue

We should spellcheck the project code before considering a spellchecker as part of the pipeline.
The following haskell files are covered by this PR.

- `lib/FreeC/Pass/ResolverPass.hs`
- `lib/FreeC/Pass/TypeInferencePass.hs`
- `lib/FreeC/Monad/Class/Hoistable.hs`
- `lib/FreeC/Monad/Reporter.hs`
- `lib/FreeC/Monad/Converter.hs`
- `lib/FreeC/Frontend/IR/PragmaParser.hs`

### Description of the Change

I used the `Code Spell Checker` plugin for VSCode to find and fix typos. I ignored common abbreviations used in the code like `eval` or `iface`.

### Alternate Designs

In the file `lib/FreeC/Pass/TypeInferencePass.hs` the term `unabstracted` is used and not known to the spell checker. I considered to replace it with another term like `concrete` but wasn't sure whether this would be fitting here. Therefore I just considered `unabstracted` to be an uncommon but legal word.

### Possible Drawbacks

Some uncommon words (e.g. `scrutinee`, `unabstracted`) and common abbreviations (e.g. `eval`, `mgu`, etc.) have to be manually ignored.

### Verification Process

All changes I made are located in comments.
