### PR TITLE
Prevent name conflicts between imported modules

### DIFF
--- a/example/Proofs/ListFunctorProofs.v
+++ b/example/Proofs/ListFunctorProofs.v
@@ -10,10 +10,10 @@ Require Import Coq.Logic.FunctionalExtensionality.
    just apply [quickCheck] *)
 Theorem prop_map_id_theorem : quickCheck prop_map_id.
 Proof.
-  simpl. intros Shape Pos t0. unfold id.
+  simpl. intros Shape Pos t0. unfold Data.Function.id.
   apply f_equal. extensionality fxs.
   induction fxs using FreeList_ind
-    with (P := fun xs => map Shape Pos (pure (fun x => x)) (pure xs) = pure xs).
+    with (P := fun xs => Data.List.map Shape Pos (pure (fun x => x)) (pure xs) = pure xs).
   - (* fxs = pure nil *)              simpl. reflexivity.
   - (* fxs = pure (cons fxs1 fxs2) *) simpl. unfold Cons. do 2 apply f_equal. apply IHfxs1.
   - (* fxs = pure xs *)               simpl. apply IHfxs.

--- a/src/lib/FreeC/Backend/Coq/Converter/Module.hs
+++ b/src/lib/FreeC/Backend/Coq/Converter/Module.hs
@@ -124,14 +124,14 @@ convertImportDecl (IR.ImportDecl _ modName) = do
 --   from the given library.
 --
 --   Modules from the base library are imported via @From Base Require Import@
---   sentences. Other external modules are imported via @From ... Require@
+--   sentences. Other external modules are imported via @From … Require@
 --   sentences, which means that references to these modules' contents must
 --   be qualified in the code.
 generateImport :: Coq.ModuleIdent -> IR.ModName -> Converter Coq.Sentence
 generateImport libName modName = return
   (mkRequireSentence libName [Coq.ident (showPretty modName)])
  where
-  -- | Makes a @From ... Require Import ...@ or  @From ... Require ...@.
+  -- | Makes a @From … Require Import …@ or  @From … Require …@.
   mkRequireSentence :: Coq.ModuleIdent -> [Coq.ModuleIdent] -> Coq.Sentence
   mkRequireSentence | libName == Coq.Base.baseLibName = Coq.requireImportFrom
                     | otherwise                       = Coq.requireFrom

--- a/src/lib/FreeC/Backend/Coq/Converter/Module.hs
+++ b/src/lib/FreeC/Backend/Coq/Converter/Module.hs
@@ -124,7 +124,9 @@ convertImportDecl (IR.ImportDecl _ modName) = do
 --   from the given library.
 --
 --   Modules from the base library are imported via @From Base Require Import@
---   sentences and all other modules are also exported.
+--   sentences. Other external modules are imported via @From ... Require@
+--   sentences, which means that references to these modules' contents must
+--   be qualified in the code.
 generateImport :: Coq.ModuleIdent -> IR.ModName -> Converter Coq.Sentence
 generateImport libName modName = return
   (mkRequireSentence libName [Coq.ident (showPretty modName)])
@@ -132,4 +134,4 @@ generateImport libName modName = return
   -- | Makes a @From ... Require Import ...@ or  @From ... Require Export ...@.
   mkRequireSentence :: Coq.ModuleIdent -> [Coq.ModuleIdent] -> Coq.Sentence
   mkRequireSentence | libName == Coq.Base.baseLibName = Coq.requireImportFrom
-                    | otherwise                       = Coq.requireExportFrom
+                    | otherwise                       = Coq.requireFrom

--- a/src/lib/FreeC/Backend/Coq/Converter/Module.hs
+++ b/src/lib/FreeC/Backend/Coq/Converter/Module.hs
@@ -114,7 +114,7 @@ convertImportDecls imports = do
   imports' <- mapM convertImportDecl imports
   return (Coq.Base.imports : imports')
 
--- | Convert a import declaration.
+-- | Convert an import declaration.
 convertImportDecl :: IR.ImportDecl -> Converter Coq.Sentence
 convertImportDecl (IR.ImportDecl _ modName) = do
   Just iface <- inEnv $ lookupAvailableModule modName
@@ -131,7 +131,7 @@ generateImport :: Coq.ModuleIdent -> IR.ModName -> Converter Coq.Sentence
 generateImport libName modName = return
   (mkRequireSentence libName [Coq.ident (showPretty modName)])
  where
-  -- | Makes a @From ... Require Import ...@ or  @From ... Require Export ...@.
+  -- | Makes a @From ... Require Import ...@ or  @From ... Require ...@.
   mkRequireSentence :: Coq.ModuleIdent -> [Coq.ModuleIdent] -> Coq.Sentence
   mkRequireSentence | libName == Coq.Base.baseLibName = Coq.requireImportFrom
                     | otherwise                       = Coq.requireFrom

--- a/src/lib/FreeC/Backend/Coq/Syntax.hs
+++ b/src/lib/FreeC/Backend/Coq/Syntax.hs
@@ -37,6 +37,7 @@ module FreeC.Backend.Coq.Syntax
     -- * Imports
   , requireImportFrom
   , requireExportFrom
+  , requireFrom
   )
 where
 
@@ -223,3 +224,8 @@ requireImportFrom library modules = ModuleSentence
 requireExportFrom :: ModuleIdent -> [ModuleIdent] -> Sentence
 requireExportFrom library modules = ModuleSentence
   (Require (Just library) (Just Export) (NonEmpty.fromList modules))
+
+-- | Creates a @From ... Require ...@ sentence.
+requireFrom :: ModuleIdent -> [ModuleIdent] -> Sentence
+requireFrom library modules = ModuleSentence
+  (Require (Just library) Nothing (NonEmpty.fromList modules))

--- a/src/lib/FreeC/Backend/Coq/Syntax.hs
+++ b/src/lib/FreeC/Backend/Coq/Syntax.hs
@@ -227,5 +227,5 @@ requireExportFrom library modules = ModuleSentence
 
 -- | Creates a @From ... Require ...@ sentence.
 requireFrom :: ModuleIdent -> [ModuleIdent] -> Sentence
-requireFrom library modules = ModuleSentence
-  (Require (Just library) Nothing (NonEmpty.fromList modules))
+requireFrom library modules =
+  ModuleSentence (Require (Just library) Nothing (NonEmpty.fromList modules))

--- a/src/lib/FreeC/Backend/Coq/Syntax.hs
+++ b/src/lib/FreeC/Backend/Coq/Syntax.hs
@@ -215,17 +215,17 @@ disj t1 t2 = app (Qualid (bare "op_\\/__")) [t1, t2]
 -- Imports                                                                   --
 -------------------------------------------------------------------------------
 
--- | Creates a @From ... Require Import ...@ sentence.
+-- | Creates a @From … Require Import …@ sentence.
 requireImportFrom :: ModuleIdent -> [ModuleIdent] -> Sentence
 requireImportFrom library modules = ModuleSentence
   (Require (Just library) (Just Import) (NonEmpty.fromList modules))
 
--- | Creates a @From ... Require Export ...@ sentence.
+-- | Creates a @From … Require Export …@ sentence.
 requireExportFrom :: ModuleIdent -> [ModuleIdent] -> Sentence
 requireExportFrom library modules = ModuleSentence
   (Require (Just library) (Just Export) (NonEmpty.fromList modules))
 
--- | Creates a @From ... Require ...@ sentence.
+-- | Creates a @From … Require …@ sentence.
 requireFrom :: ModuleIdent -> [ModuleIdent] -> Sentence
 requireFrom library modules =
   ModuleSentence (Require (Just library) Nothing (NonEmpty.fromList modules))

--- a/src/lib/FreeC/Pass/ExportPass.hs
+++ b/src/lib/FreeC/Pass/ExportPass.hs
@@ -101,13 +101,13 @@ exportInterface modName = do
                      }
     )
  where
-   -- | Tests whether to export the given entry.
-   --
-   --   Only top-level entries that are declared in the module are exported.
-   --   Since the original names of entries are qualified with the name of the
-   --   module they are declared in, we can tell whether an entry is declared
-   --   in the exported module by comparing the prefix of its original name
-   --   with the module name.
+  -- | Tests whether to export the given entry.
+  --
+  --   Only top-level entries that are declared in the module are exported.
+  --   Since the original names of entries are qualified with the name of the
+  --   module they are declared in, we can tell whether an entry is declared
+  --   in the exported module by comparing the prefix of its original name
+  --   with the module name.
   isExported :: EnvEntry -> Bool
   isExported entry = case entryName entry of
     IR.Qual modName' _ -> modName' == modName

--- a/src/lib/FreeC/Pass/ExportPass.hs
+++ b/src/lib/FreeC/Pass/ExportPass.hs
@@ -8,8 +8,8 @@
 --   can be expanded properly.
 --   Additionally, all Coq identifiers of exported entries are qualified with
 --   their original module name in the module interface.
---   This prevents name conflicts when several modules that use the same identifier
---   are imported.
+--   This prevents name conflicts when several modules that use the same
+--   identifier are imported.
 --
 --   = Examples
 --
@@ -42,7 +42,8 @@
 --   for the top-level function @B.foo@. Entries for local variables such as
 --   @x@ are not part of @B@'s interface. Since 'interfaceEntries' is a set,
 --   the @Prelude@ entries which are both implicitly imported by @B@ and part
---   of the imported interface from @A@ are not listed twice in @B@'s interface.
+--   of the imported interface from @A@ are not listed twice in @B@'s
+--   interface.
 --
 --   = Specification
 --
@@ -66,11 +67,9 @@ where
 
 import qualified Data.Map.Strict               as Map
 import qualified Data.Set                      as Set
-import qualified Data.Text                     as Text
-
-import           Language.Coq.Gallina
 
 import qualified FreeC.Backend.Coq.Base        as Coq.Base
+import qualified FreeC.Backend.Coq.Syntax      as Coq
 import           FreeC.Environment
 import           FreeC.Environment.ModuleInterface
 import           FreeC.Environment.Entry
@@ -102,22 +101,22 @@ exportInterface modName = do
                      }
     )
  where
-   -- Tests whether to export the given entry.
+   -- | Tests whether to export the given entry.
    --
-   -- Only top-level entries that are declared in the module are exported.
-   -- Since the original names of entries are qualified with the name of the
-   -- module they are declared in, we can tell whether an entry is declared
-   -- in the exported module by comparing the prefix of its original name
-   -- with the module name.
+   --   Only top-level entries that are declared in the module are exported.
+   --   Since the original names of entries are qualified with the name of the
+   --   module they are declared in, we can tell whether an entry is declared
+   --   in the exported module by comparing the prefix of its original name
+   --   with the module name.
   isExported :: EnvEntry -> Bool
   isExported entry = case entryName entry of
     IR.Qual modName' _ -> modName' == modName
     IR.UnQual _        -> False
 
-  -- Qualifies the Coq identifier in the module interface with the module name
-  -- when an entry of the module is exported.
-  -- This ensures that any module that imports the entry uses its qualified
-  -- name, which prevents name conflicts between imported modules.
+  -- | Qualifies the Coq identifier in the module interface with the module
+  --   name when an entry of the module is exported.
+  --   This ensures that any module that imports the entry uses its qualified
+  --   name, which prevents name conflicts between imported modules.
   qualifyExportedIdent :: EnvEntry -> EnvEntry
   qualifyExportedIdent entry
     | isExported entry = if isConEntry entry
@@ -127,9 +126,8 @@ exportInterface modName = do
       else entry { entryIdent = qualifyIdent (entryIdent entry) }
     | otherwise = entry
 
-
-  -- Qualifies an unqualified Coq identifier with the module name.
-  -- A qualified Coq identifer is not modified.
-  qualifyIdent :: Qualid -> Qualid
-  qualifyIdent (         Bare coqName ) = Qualified (Text.pack modName) coqName
-  qualifyIdent qualName@(Qualified _ _) = qualName
+  -- | Qualifies an unqualified Coq identifier with the module name.
+  --   A qualified Coq identifer is not modified.
+  qualifyIdent :: Coq.Qualid -> Coq.Qualid
+  qualifyIdent (Coq.Bare coqName) = Coq.Qualified (Coq.ident modName) coqName
+  qualifyIdent qualName@(Coq.Qualified _ _) = qualName


### PR DESCRIPTION
### Issue

Closes #20 

### Description of the Change

As described in the issue, if there were two modules that used the same identifiers and then those two modules were imported by a third module, there was a conflict between names as imported identifiers were not renamed or qualified.

If this pull request is merged, any time a module is exported, the Coq identifier in the module interface will be qualified with the name of the module. 
This way, such name conflicts are avoided.
The change occurs in the compiler's `ExportPass`. 

Additionally, the translation of `Import` declarations was changed so that external names can no longer be referred to by their short names in Coq, but have to be qualified. This was done by changing the translation of an import declaration (except those importing from the `Base` library) from the `From Generated Require Export [Module]` sentence to `From Generated Require [Module]`. 

Names defined in the `Base` library do not have to be qualified.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
I tested the implementation by translating settings like the one described in #20, with different constellations of clashing names. 
I tested that chained imports were translated correctly.
I tested that the change worked in the presence of renaming (for example, by having a data type declaration `data Foo = Foo`).
I also tested that type synonyms could still be handled correctly by translating the example given in the documentation of the compiler's `Import Pass`:

```haskell
module A where 
data Foo = Foo

module B where 
import A
type Bar a = Foo -> a

module C where 
import B
baz :: Bar ()
baz x = ()
```
All examples produced compilable Coq programs.

Dedicated test cases should be added as soon as possible.

### Additional Notes

If this pull request is merged, all external identifiers are required to be qualified with their original module name in the generated Coq code.
As a consequence, Coq programs importing the generated modules (e.g. proofs of the generated code) must now use qualified names if they refer to modules imported into the generated module. 

E.g. `ListFunctorProofs` in `examples` imports the module `ListFunctor` and refers to `map` and `id` in its proofs, which are imported from the modules `Data.List` and `Data.Function` in `ListFunctor`. These references must now be qualified as `Data.List.map` and `Data.Function.id` in `ListFunctorProofs`.