### PR TITLE
Spell Check Block 3

### DIFF
--- a/src/lib/FreeC/IR/Inlining.hs
+++ b/src/lib/FreeC/IR/Inlining.hs
@@ -88,7 +88,7 @@ inlineExpr decls = inlineAndBind
   --   If a function is inlined, fresh free variables are introduced for the
   --   function arguments. The first two components of the returned tuple
   --   contain the names of the type variables and variables that still need
-  --   to be bound. 
+  --   to be bound.
   --   Function application and visible type application expressions
   --   automatically substitute the corresponding argument for
   --   the passed value.

--- a/src/lib/FreeC/IR/Inlining.hs
+++ b/src/lib/FreeC/IR/Inlining.hs
@@ -26,9 +26,11 @@ inlineFuncDecls decls decl = do
   rhs' <- inlineExpr decls rhs
   return decl { IR.funcDeclRhs = rhs' }
 
--- | Inlines the right hand sides of the given function declarations into an
---   expression. This step is repeated until the expression remains unchanged
---   or no more function declarations are available.
+-- | Inlines the right-hand sides of the given function declarations into an
+--   expression.
+--
+--   Inlining is repeated until the expression remains unchanged or no more
+--   function declarations are available.
 --   That is done under the assumption that regarding a certain position
 --   of the given expression every given function should be inlined at
 --   most once in order to avoid endless inlining.

--- a/src/lib/FreeC/IR/Inlining.hs
+++ b/src/lib/FreeC/IR/Inlining.hs
@@ -18,8 +18,8 @@ import           FreeC.Monad.Converter
 import           FreeC.Monad.Reporter
 import           FreeC.Pretty
 
--- | Inlines the right hand sides of the given function declarations into
---   the right hand sides of other function declarations.
+-- | Inlines the right-hand sides of the given function declarations into
+--   the right-hand sides of another function declaration.
 inlineFuncDecls :: [IR.FuncDecl] -> IR.FuncDecl -> Converter IR.FuncDecl
 inlineFuncDecls decls decl = do
   let rhs = IR.funcDeclRhs decl
@@ -39,7 +39,7 @@ inlineExpr []    = return
 inlineExpr decls = inlineAndBind
  where
   -- | Maps the names of function declarations in 'decls' to the arguments
-  --   and right hand sides of the functions.
+  --   and right-hand sides of the functions.
   declMap :: Map IR.QName ([IR.TypeVarDecl], [IR.VarPat], IR.Expr)
   declMap = foldr insertFuncDecl Map.empty decls
 
@@ -147,7 +147,7 @@ inlineExpr decls = inlineAndBind
   inlineExpr' expr@(IR.ErrorExpr  _ _ _) = return ([], [], expr)
   inlineExpr' expr@(IR.IntLiteral _ _ _) = return ([], [], expr)
 
-  -- | Performs inlining on the right hand side of the given @case@-expression
+  -- | Performs inlining on the right-hand side of the given @case@-expression
   --   alternative.
   inlineAlt :: IR.Alt -> Converter IR.Alt
   inlineAlt (IR.Alt srcSpan conPat varPats expr) = shadowVarPats varPats $ do

--- a/src/lib/FreeC/Pipeline.hs
+++ b/src/lib/FreeC/Pipeline.hs
@@ -7,7 +7,10 @@
 
 module FreeC.Pipeline where
 
+import qualified FreeC.IR.Syntax               as IR
+import           FreeC.Monad.Converter
 import           FreeC.Pass
+import           FreeC.Pass.CompletePatternPass
 import           FreeC.Pass.DefineDeclPass
 import           FreeC.Pass.DependencyAnalysisPass
 import           FreeC.Pass.EtaConversionPass
@@ -16,13 +19,10 @@ import           FreeC.Pass.ImplicitPreludePass
 import           FreeC.Pass.ImportPass
 import           FreeC.Pass.KindCheckPass
 import           FreeC.Pass.PartialityAnalysisPass
-import           FreeC.Pass.TypeSignaturePass
-import           FreeC.Pass.TypeInferencePass
 import           FreeC.Pass.QualifierPass
 import           FreeC.Pass.ResolverPass
-import           FreeC.Pass.CompletePatternPass
-import qualified FreeC.IR.Syntax               as IR
-import           FreeC.Monad.Converter
+import           FreeC.Pass.TypeInferencePass
+import           FreeC.Pass.TypeSignaturePass
 
 -- | The passes of the compiler pipeline.
 pipeline :: [Pass IR.Module]

--- a/src/lib/FreeC/Pretty.hs
+++ b/src/lib/FreeC/Pretty.hs
@@ -115,6 +115,7 @@ hPutPrettyLn :: Pretty a => Handle -> a -> IO ()
 hPutPrettyLn h = hPutPretty h . TrailingLine
 
 -- | Writes a pretty printable value to the file located at the given path.
+--
 --   There is always a trailing newline at the end of the file.
 writePrettyFile :: Pretty a => FilePath -> a -> IO ()
 writePrettyFile filename = withFile filename WriteMode . flip hPutPrettyLn

--- a/src/lib/FreeC/Pretty.hs
+++ b/src/lib/FreeC/Pretty.hs
@@ -123,6 +123,6 @@ writePrettyFile filename = withFile filename WriteMode . flip hPutPrettyLn
 -- Conversion                                                                --
 -------------------------------------------------------------------------------
 
--- | Convers a pretty printable value to a string.
+-- | Converts a pretty printable value to a string.
 showPretty :: Pretty a => a -> String
 showPretty = LazyText.unpack . displayT . renderPretty'

--- a/src/lib/FreeC/Util/Config.hs
+++ b/src/lib/FreeC/Util/Config.hs
@@ -50,7 +50,7 @@ decodeTomlConfig filename contents = either
   decodeTomlDocument
   (parseTomlDoc filename (Text.pack contents))
  where
-  -- | Decodes a TOML document using the "Aeson" interace.
+  -- | Decodes a TOML document using the "Aeson" interface.
   decodeTomlDocument :: MonadReporter r => Aeson.FromJSON a => Toml.Table -> r a
   decodeTomlDocument document = case Aeson.fromJSON (Aeson.toJSON document) of
     Aeson.Error msg ->

--- a/src/lib/FreeC/Util/Predicate.hs
+++ b/src/lib/FreeC/Util/Predicate.hs
@@ -6,11 +6,13 @@ module FreeC.Util.Predicate where
 import           Control.Monad
 import           Control.Monad.Reader           ( )
 
--- | Conjunction of two boolean predicates.
+-- | Combines two predicates to a new predicate whose result is the conjunction
+--   of the results of the two given predicates.
 (.&&.) :: (a -> Bool) -> (a -> Bool) -> a -> Bool
 (.&&.) = liftM2 (&&)
 
--- | Disjunction of two boolean predicates.
+-- | Combines two predicates to a new predicate whose result is the disjunction
+--   of the results of the two given predicates.
 (.||.) :: (a -> Bool) -> (a -> Bool) -> a -> Bool
 (.||.) = liftM2 (||)
 

--- a/src/test/FreeC/Backend/Coq/Analysis/ConstantArgumentsTests.hs
+++ b/src/test/FreeC/Backend/Coq/Analysis/ConstantArgumentsTests.hs
@@ -29,7 +29,7 @@ identifyConstArgIdents =
 -- Test                                                                      --
 -------------------------------------------------------------------------------
 
--- | Test group for @identifyConstArgs@.
+-- | Test group for 'identifyConstArgs'.
 testConstantArguments :: Spec
 testConstantArguments =
   describe "FreeC.Backend.Coq.Analysis.ConstantArguments" $ do

--- a/src/test/FreeC/Backend/Coq/Converter/ExprTests.hs
+++ b/src/test/FreeC/Backend/Coq/Converter/ExprTests.hs
@@ -182,11 +182,14 @@ testConvertFuncApp = context "function applications" $ do
         "a" <- defineTestTypeVar "a"
         "x" <- defineTestVar "x"
         "y" <- defineTestVar "y"
-        "f @a x y"
-          `shouldConvertExprTo` "x >>= (fun (x_0 : a) => y >>= (fun (y_0 : a) => @f Shape Pos a x_0 y_0))"
+        shouldConvertExprTo "f @a x y"
+          $  "x >>= (fun (x_0 : a) =>"
+          ++ "  y >>= (fun (y_0 : a) => @f Shape Pos a x_0 y_0))"
 
   it
-      "converts function applications with one non-strict and one strict argument correctly"
+      (  "converts function applications with one non-strict and one"
+      ++ "strict argument correctly"
+      )
     $ shouldSucceedWith
     $ do
         "f" <- defineStrictTestFunc "f" [False, True] "forall a. a -> a -> a"

--- a/src/test/FreeC/Backend/Coq/Converter/ExprTests.hs
+++ b/src/test/FreeC/Backend/Coq/Converter/ExprTests.hs
@@ -21,7 +21,7 @@ import           FreeC.Test.Expectations
 
 -- | Parses the given IR expression, converts it to Coq using 'convertExpr'
 --   and sets the expectation that the resulting AST is equal to the given
---   output when pretty printed modulo white space.
+--   output when pretty printed modulo whitespace.
 shouldConvertExprTo :: String -> String -> Converter Expectation
 shouldConvertExprTo inputStr expectedOutputStr = do
   input  <- parseTestExpr inputStr
@@ -53,14 +53,14 @@ testConvertExpr = describe "FreeC.Backend.Coq.Converter.Expr.convertExpr" $ do
 -- | Test group for translation of constructor application expressions.
 testConvertConApp :: Spec
 testConvertConApp = context "constructor applications" $ do
-  it "converts 0-ary constructor applications correctly"
+  it "converts nullary constructor applications correctly"
     $ shouldSucceedWith
     $ do
         "D"        <- defineTestTypeCon "D" 0 ["C"]
         ("c", "C") <- defineTestCon "C" 0 "D"
         "C" `shouldConvertExprTo` "C Shape Pos"
 
-  it "converts polymorphic 0-ary constructor applications correctly"
+  it "converts polymorphic nullary constructor applications correctly"
     $ shouldSucceedWith
     $ do
         "D"        <- defineTestTypeCon "D" 1 ["C"]
@@ -108,7 +108,7 @@ testConvertConApp = context "constructor applications" $ do
 -- | Test group for translation of function application expressions.
 testConvertFuncApp :: Spec
 testConvertFuncApp = context "function applications" $ do
-  it "converts 0-ary function (pattern-binding) applications correctly"
+  it "converts nullary function (pattern-binding) applications correctly"
     $ shouldSucceedWith
     $ do
         "f" <- defineTestFunc "f" 0 "forall a. a"

--- a/src/test/FreeC/Backend/Coq/Converter/ExprTests.hs
+++ b/src/test/FreeC/Backend/Coq/Converter/ExprTests.hs
@@ -11,9 +11,9 @@ import           FreeC.Backend.Coq.Converter.Expr
 import           FreeC.Backend.Coq.Pretty       ( )
 import           FreeC.Monad.Class.Testable
 import           FreeC.Monad.Converter
-import           FreeC.Test.Parser
 import           FreeC.Test.Environment
 import           FreeC.Test.Expectations
+import           FreeC.Test.Parser
 
 -------------------------------------------------------------------------------
 -- Expectation setters                                                       --

--- a/src/test/FreeC/Backend/Coq/Converter/FuncDecl/NonRecTests.hs
+++ b/src/test/FreeC/Backend/Coq/Converter/FuncDecl/NonRecTests.hs
@@ -21,7 +21,7 @@ import           FreeC.Test.Parser
 
 -- | Parses the given IR function declaration, converts it to Coq using
 --   'convertNonRecFuncDecl' and sets the expectation that the resulting
---   Coq code equals the given expected output modulo white space.
+--   Coq code equals the given expected output modulo whitespace.
 shouldConvertNonRecTo :: String -> String -> Converter Expectation
 shouldConvertNonRecTo inputStr expectedOutputStr = do
   input  <- parseTestFuncDecl inputStr

--- a/src/test/FreeC/Backend/Coq/Converter/FuncDecl/Rec/WithHelpersTests.hs
+++ b/src/test/FreeC/Backend/Coq/Converter/FuncDecl/Rec/WithHelpersTests.hs
@@ -242,8 +242,6 @@ testConvertRecFuncDeclWithHelpers = context "with helper functions" $ do
           ++ "  := xs >>= (fun (xs_0 : List Shape Pos a) =>"
           ++ "           @even_len_0 Shape Pos a xs_0). "
 
-
-
   it "translates recursive functions with nested case expressions correctly"
     $ shouldSucceedWith
     $ do
@@ -355,7 +353,9 @@ testConvertRecFuncDeclWithHelpers = context "with helper functions" $ do
           ++ "        @foo_0 Shape Pos a xs_0 y)))."
 
   it
-      "translates recursive functions with nested pattern matching on recursive argument correctly"
+      (  "translates recursive functions with nested pattern matching on"
+      ++ "recursive argument correctly"
+      )
     $ shouldSucceedWith
     $ do
         "List"           <- defineTestTypeCon "List" 1 ["Nil", "Cons"]
@@ -535,7 +535,9 @@ testConvertRecFuncDeclWithHelpers = context "with helper functions" $ do
           ++ " := @length_0 Shape Pos a xs."
 
   it
-      "translates recursive functions with strict and non-strict arguments correctly"
+      (  "translates recursive functions with strict and non-strict"
+      ++ "arguments correctly"
+      )
     $ shouldSucceedWith
     $ do
         "List"           <- defineTestTypeCon "List" 1 ["Nil", "Cons"]
@@ -582,7 +584,9 @@ testConvertRecFuncDeclWithHelpers = context "with helper functions" $ do
           ++ " := xs >>= (fun (xs_0 : List Shape Pos a) =>"
           ++ "             @interleave_0 Shape Pos a xs_0 ys)."
   it
-      "converts recursive functions with a strict argument preceding the decreasing argument correctly"
+      (  "converts recursive functions with a strict argument preceding"
+      ++ "the decreasing argument correctly"
+      )
     $ shouldSucceedWith
     $ do
         "List"           <- defineTestTypeCon "List" 1 ["Nil", "Cons"]
@@ -614,7 +618,9 @@ testConvertRecFuncDeclWithHelpers = context "with helper functions" $ do
           ++ " := xs >>= (fun (xs_0 : List Shape Pos a) =>"
           ++ "              @foo_0 Shape Pos a x xs_0)."
   it
-      "translates recursive functions affected by the eta conversion pass correctly"
+      (  "translates recursive functions affected by the eta conversion"
+      ++ "pass correctly"
+      )
     $ shouldSucceedWith
     $ avoidLaziness
     $ do
@@ -641,16 +647,19 @@ testConvertRecFuncDeclWithHelpers = context "with helper functions" $ do
           (  "(* Helper functions for append *)"
           ++ " Fixpoint append_0"
           ++ "   (Shape : Type) (Pos : Shape -> Type) {a b : Type}"
-          ++ "   (xs : List Shape Pos a) (ys : Free Shape Pos (List Shape Pos a))"
+          ++ "   (xs : List Shape Pos a)"
+          ++ "   (ys : Free Shape Pos (List Shape Pos a))"
           ++ "   {struct xs} : Free Shape Pos (List Shape Pos a)"
           ++ "  := match xs with"
           ++ "     | nil => ys"
           ++ "     | cons x xs' =>"
           ++ "         @Cons Shape Pos a x"
           ++ "           ((fun y =>"
-          ++ "               @const Shape Pos (List Shape Pos a) (Unit Shape Pos)"
+          ++ "               @const Shape Pos (List Shape Pos a)"
+          ++ "                 (Unit Shape Pos)"
           ++ "                 (xs' >>= (fun (xs'_0 : List Shape Pos a) =>"
-          ++ "                   @append_0 Shape Pos a (Unit Shape Pos) xs'_0 ys))"
+          ++ "                   @append_0 Shape Pos a"
+          ++ "                     (Unit Shape Pos) xs'_0 ys))"
           ++ "                 y)"
           ++ "            (Tt Shape Pos))"
           ++ "     end."
@@ -658,7 +667,8 @@ testConvertRecFuncDeclWithHelpers = context "with helper functions" $ do
           ++ "   (Shape : Type) (Pos : Shape -> Type) {a b : Type}"
           ++ "   (xs : Free Shape Pos (List Shape Pos a))"
           ++ "   (ys : Free Shape Pos (List Shape Pos a))"
-          ++ "   : Free Shape Pos (Free Shape Pos b -> Free Shape Pos (List Shape Pos a))"
+          ++ "   : Free Shape Pos"
+          ++ "       (Free Shape Pos b -> Free Shape Pos (List Shape Pos a))"
           ++ "  := pure (fun y =>"
           ++ "       @const Shape Pos (List Shape Pos a) b"
           ++ "         (xs >>= (fun (xs_0 : List Shape Pos a) =>"

--- a/src/test/FreeC/Backend/Coq/Converter/FuncDecl/Rec/WithHelpersTests.hs
+++ b/src/test/FreeC/Backend/Coq/Converter/FuncDecl/Rec/WithHelpersTests.hs
@@ -24,7 +24,7 @@ import           FreeC.Test.Parser
 
 -- | Parses the given function declarations, converts them to Coq using
 --   'convertRecFuncDeclsWithHelpers' and expects the resulting Coq code
---   to equal the given expected output modulo white space.
+--   to equal the given expected output modulo whitespace.
 shouldConvertWithHelpersTo :: [String] -> String -> Converter Expectation
 shouldConvertWithHelpersTo inputStrs expectedOutputStr = do
   input  <- mapM parseTestFuncDecl inputStrs

--- a/src/test/FreeC/Backend/Coq/Converter/FuncDecl/Rec/WithSectionsTests.hs
+++ b/src/test/FreeC/Backend/Coq/Converter/FuncDecl/Rec/WithSectionsTests.hs
@@ -23,7 +23,7 @@ import           FreeC.Test.Parser
 
 -- | Parses the given function declarations, converts them to Coq using
 --   'convertRecFuncDeclsWithSection' and expects the resulting Coq code
---   to equal the given expected output modulo white space.
+--   to equal the given expected output modulo whitespace.
 convertRecFuncDeclsWithSectionTo :: [String] -> String -> Converter Expectation
 convertRecFuncDeclsWithSectionTo inputStrs expectedOutputStr = do
   input     <- mapM parseTestFuncDecl inputStrs
@@ -159,7 +159,7 @@ testConvertRecFuncDeclWithSections = context "with section sentences" $ do
           ++ "  : Free Shape Pos (List Shape Pos a)"
           ++ "  := mapAlt'_0 Shape Pos b a f xs."
 
-  it "does not create variable sentences for unsued constant arguments"
+  it "does not create variable sentences for unused constant arguments"
     $ shouldSucceedWith
     $ do
         "List"           <- defineTestTypeCon "List" 1 ["Nil", "Cons"]

--- a/src/test/FreeC/Backend/Coq/Converter/TypeTests.hs
+++ b/src/test/FreeC/Backend/Coq/Converter/TypeTests.hs
@@ -11,9 +11,9 @@ import           FreeC.Backend.Coq.Converter.Type
 import           FreeC.Backend.Coq.Pretty       ( )
 import           FreeC.Monad.Class.Testable
 import           FreeC.Monad.Converter
-import           FreeC.Test.Parser
 import           FreeC.Test.Environment
 import           FreeC.Test.Expectations
+import           FreeC.Test.Parser
 
 -------------------------------------------------------------------------------
 -- Expectation setters                                                       --

--- a/src/test/FreeC/Backend/Coq/ConverterTests.hs
+++ b/src/test/FreeC/Backend/Coq/ConverterTests.hs
@@ -12,8 +12,8 @@ import           FreeC.Backend.Coq.Converter.TypeTests
 -- | Test group for all @FreeC.Backend.Coq.Converter@ tests.
 testConverter :: Spec
 testConverter = do
-  testConvertType
-  testConvertTypeDecl
   testConvertDataDecls
   testConvertExpr
   testConvertFuncDecl
+  testConvertType
+  testConvertTypeDecl

--- a/src/test/FreeC/Backend/Coq/Tests.hs
+++ b/src/test/FreeC/Backend/Coq/Tests.hs
@@ -7,13 +7,13 @@ where
 
 import           Test.Hspec
 
-import           FreeC.Backend.Coq.Analysis.DecreasingArgumentsTests
 import           FreeC.Backend.Coq.Analysis.ConstantArgumentsTests
+import           FreeC.Backend.Coq.Analysis.DecreasingArgumentsTests
 import           FreeC.Backend.Coq.ConverterTests
 
 -- | Test group for tests of modules below @FreeC.Backend.Coq@.
 testCoqBackend :: Spec
 testCoqBackend = do
-  testDecreasingArguments
   testConstantArguments
   testConverter
+  testDecreasingArguments

--- a/src/test/FreeC/PipelineTests.hs
+++ b/src/test/FreeC/PipelineTests.hs
@@ -1,5 +1,5 @@
 -- | This module contains tests for passes that are part of the compiler
---   pipeline "FreeC.Pipeline".
+--   pipeline (see "FreeC.Pipeline").
 
 module FreeC.PipelineTests
   ( testPipeline
@@ -15,7 +15,7 @@ import           FreeC.Pass.PartialityAnalysisPassTests
 import           FreeC.Pass.ResolverPassTests
 import           FreeC.Pass.TypeInferencePassTests
 
--- | Test group for 'FreeC.Pipeline.runPipeline' tests.
+-- | Test group for tests of passes in 'FreeC.Pipeline.pipeline'.
 testPipeline :: Spec
 testPipeline = do
   testCompletePatternPass


### PR DESCRIPTION
I've spell checked strings and comments in the following files (block 3).

```
./test/FreeC/Backend/Coq/Converter/ExprTests.hs
./test/FreeC/Backend/Coq/Converter/FuncDecl/NonRecTests.hs
./test/FreeC/Backend/Coq/Converter/FuncDecl/Rec/WithSectionsTests.hs
./test/FreeC/Backend/Coq/Converter/FuncDecl/Rec/WithHelpersTests.hs
./test/FreeC/Backend/Coq/Converter/FuncDecl/RecTests.hs
./test/FreeC/Backend/Coq/Converter/TypeTests.hs
./test/FreeC/Backend/Coq/Tests.hs
./test/FreeC/Backend/Coq/Analysis/ConstantArgumentsTests.hs
./test/FreeC/Backend/Coq/Analysis/DecreasingArgumentsTests.hs
./test/FreeC/Backend/Coq/ConverterTests.hs
./test/FreeC/PipelineTests.hs
./lib/FreeC/Pretty.hs
./lib/FreeC/Pipeline.hs
./lib/FreeC/Util/Parsec.hs
./lib/FreeC/Util/Predicate.hs
./lib/FreeC/Util/Config.hs
./lib/FreeC/IR/Inlining.hs
./lib/FreeC/IR/Syntax/FuncDecl.hs
```

I had to add the following words to my spell checkers dictionary.

```
AST
Coq
JSON
TOML
boolean
disjunction
inlined
inlining
inlines
nullary
polymorphically
subexpression
subterms
unapplied
unary
whitespace
```