### PR TITLE
Add partial alternatives for subterm functions

### DIFF
--- a/src/lib/FreeC/Backend/Coq/Converter/FuncDecl/Rec/WithHelpers.hs
+++ b/src/lib/FreeC/Backend/Coq/Converter/FuncDecl/Rec/WithHelpers.hs
@@ -95,7 +95,7 @@ transformRecFuncDecl (IR.FuncDecl srcSpan declIdent typeArgs args maybeRetType e
     -- Generate main function declaration. The main function's right hand side
     -- is constructed by replacing all case expressions of the decreasing
     -- argument by an invocation of the corresponding recursive helper function.
-    let (Just mainExpr) = replaceSubterms expr (zip caseExprsPos helperApps)
+    let mainExpr = replaceSubterms' expr (zip caseExprsPos helperApps)
         mainDecl =
           IR.FuncDecl srcSpan declIdent typeArgs args maybeRetType mainExpr
 
@@ -150,7 +150,7 @@ transformRecFuncDecl (IR.FuncDecl srcSpan declIdent typeArgs args maybeRetType e
     let boundVarTypeMap = boundVarsWithTypeAt expr caseExprPos
         boundVars =
           Map.keysSet boundVarTypeMap `Set.union` Set.fromList argNames
-        Just caseExpr  = selectSubterm expr caseExprPos
+        caseExpr       = selectSubterm' expr caseExprPos
         usedVars       = freeVarSet caseExpr
         helperArgNames = Set.toList (usedVars `Set.intersection` boundVars)
 

--- a/src/lib/FreeC/IR/Subterm.hs
+++ b/src/lib/FreeC/IR/Subterm.hs
@@ -39,8 +39,7 @@ import           Data.Composition               ( (.:) )
 import           Data.List                      ( intersperse
                                                 , isPrefixOf
                                                 )
-import           Data.Maybe                     ( fromJust
-                                                , fromMaybe
+import           Data.Maybe                     ( fromMaybe
                                                 , listToMaybe
                                                 )
 import           Data.Map.Strict                ( Map )
@@ -287,13 +286,13 @@ replaceSubterms' = foldl (\term (pos, term') -> replaceSubterm' term pos term')
 --   satisfy the provided predicate.
 findSubtermPos :: Subterm a => (a -> Bool) -> a -> [Pos]
 findSubtermPos predicate term =
-  filter (predicate . fromJust . selectSubterm term) (allPos term)
+  filter (predicate . selectSubterm' term) (allPos term)
 
 -- | Gets a list of subterms of the given expression that satisfy the
 --   provided predicate.
 findSubterms :: Subterm a => (a -> Bool) -> a -> [a]
 findSubterms predicate term =
-  filter predicate (map (fromJust . selectSubterm term) (allPos term))
+  filter predicate (map (selectSubterm' term) (allPos term))
 
 -- | Gets the first subterm of the given expression that satisfies the
 --   provided predicate.

--- a/src/lib/FreeC/IR/Subterm.hs
+++ b/src/lib/FreeC/IR/Subterm.hs
@@ -88,6 +88,9 @@ missingPosError funcName term pos =
 -------------------------------------------------------------------------------
 
 -- | Type class for AST nodes with child nodes of the same type.
+--
+--   It is a subclass of 'Pretty' so error messages involving subterms can be
+--   pretty printed.
 class Pretty a => Subterm a where
   -- | Gets the child nodes of the given AST node.
   childTerms :: a -> [a]

--- a/src/lib/FreeC/IR/Subterm.hs
+++ b/src/lib/FreeC/IR/Subterm.hs
@@ -35,6 +35,7 @@ module FreeC.IR.Subterm
   )
 where
 
+import           Control.Monad                  ( foldM )
 import           Data.Composition               ( (.:) )
 import           Data.List                      ( intersperse
                                                 , isPrefixOf
@@ -269,10 +270,7 @@ replaceSubterm' term pos term' = fromMaybe
 --
 --   Returns @Nothing@ if any of the subterms could not be replaced
 replaceSubterms :: Subterm a => a -> [(Pos, a)] -> Maybe a
-replaceSubterms term []             = return term
-replaceSubterms term ((p, e) : pes) = do
-  term' <- replaceSubterm term p e
-  replaceSubterms term' pes
+replaceSubterms = foldM (\term (pos, term') -> replaceSubterm term pos term')
 
 -- | Like 'replaceSubterms' but throws an error if any of the subterms could
 --   not be replaced.


### PR DESCRIPTION
<!--
  Have you read our Code of Conduct?
  By filing an issue or pull request, you are expected to comply with it, including treating everyone with respect:
  https://github.com/FreeProving/guidelines/blob/main/CODE_OF_CONDUCT.md
-->

### Issue

<!--
  Link to the issue that this pull request addresses.
  If there is not yet a corresponding issue, please open a new issue and then link to that issue in your pull request.
  Give any additional information that is not covered by the linked issue but might be important for the reviewer.
-->
Closes #52.

### Description of the Change

<!--
  Give a short summary of the changes you made to handle the issue.
  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
-->

Adds partial versions of some subterm functions that throw an error instead of returning `Nothing`. Also replaces some function calls with the alternative version where appropriate.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
  What process did you follow to verify that your change has the desired effects and has not introduced any regressions?
  Describe the actions you performed (including input you checked, tests you created, commands you ran, etc.), and describe the results you observed.
-->

### Additional Notes

<!-- Is there anything else worth mentioning (e.g. changes by your PR that other contributors have to be aware of, ideas for further enhancements, etc.)? -->
