### PR TITLE
Use lifted IR for type translations

### DIFF
--- a/src/lib/FreeC/Backend/Coq/Converter/Type.hs
+++ b/src/lib/FreeC/Backend/Coq/Converter/Type.hs
@@ -12,10 +12,10 @@ import qualified FreeC.LiftedIR.Syntax         as LIR
 import           FreeC.Monad.Converter
 
 -------------------------------------------------------------------------------
--- IR to Coq translation                                             --
+-- IR to Coq translation                                                     --
 -------------------------------------------------------------------------------
 
--- | Converts a Haskell type to Coq, lifting it into the @Free@ monad.
+-- | Converts a type from IR to Coq, lifting it into the @Free@ monad.
 --
 --   [\(\tau^\dagger = Free\,Shape\,Pos\,\tau^*\)]
 --     A type \(\tau\) is converted by lifting it into the @Free@ monad and
@@ -24,7 +24,7 @@ import           FreeC.Monad.Converter
 convertType :: IR.Type -> Converter Coq.Term
 convertType = convertLiftedType . liftType
 
--- | Converts a Haskell type to Coq.
+-- | Converts a type from IR to Coq.
 --
 --   In contrast to 'convertType', the type itself is not lifted into the
 --   @Free@ monad. Only the argument and return types of contained function
@@ -49,10 +49,10 @@ convertType' :: IR.Type -> Converter Coq.Term
 convertType' = convertLiftedType . liftType'
 
 -------------------------------------------------------------------------------
--- Lifted IR to Coq translation                                             --
+-- Lifted IR to Coq translation                                              --
 -------------------------------------------------------------------------------
 
--- | Converts a given type in the lifted IR to a coq term.
+-- | Converts a given type in the lifted IR to a Coq term.
 convertLiftedType :: LIR.Type -> Converter Coq.Term
 convertLiftedType (LIR.TypeVar srcSpan ident) = do
   qualid <- lookupIdentOrFail srcSpan IR.TypeScope (IR.UnQual (IR.Ident ident))

--- a/src/lib/FreeC/Backend/Coq/Converter/Type.hs
+++ b/src/lib/FreeC/Backend/Coq/Converter/Type.hs
@@ -7,7 +7,13 @@ import           FreeC.Backend.Coq.Converter.Free
 import qualified FreeC.Backend.Coq.Syntax      as Coq
 import           FreeC.Environment.LookupOrFail
 import qualified FreeC.IR.Syntax               as IR
+import           FreeC.LiftedIR.Converter.Type
+import qualified FreeC.LiftedIR.Syntax         as LIR
 import           FreeC.Monad.Converter
+
+-------------------------------------------------------------------------------
+-- IR to Coq translation                                             --
+-------------------------------------------------------------------------------
 
 -- | Converts a Haskell type to Coq, lifting it into the @Free@ monad.
 --
@@ -16,9 +22,7 @@ import           FreeC.Monad.Converter
 --     recursively converting the argument and return types of functions
 --     using 'convertType''.
 convertType :: IR.Type -> Converter Coq.Term
-convertType t = do
-  t' <- convertType' t
-  return (genericApply Coq.Base.free [] [] [t'])
+convertType = convertLiftedType . liftType
 
 -- | Converts a Haskell type to Coq.
 --
@@ -42,17 +46,25 @@ convertType t = do
 --     Type constructor applications are translated recursively but
 --     remain unchanged otherwise.
 convertType' :: IR.Type -> Converter Coq.Term
-convertType' (IR.TypeVar srcSpan ident) = do
+convertType' = convertLiftedType . liftType'
+
+-------------------------------------------------------------------------------
+-- Lifted IR to Coq translation                                             --
+-------------------------------------------------------------------------------
+
+-- | Converts a given type in the lifted IR to a coq term.
+convertLiftedType :: LIR.Type -> Converter Coq.Term
+convertLiftedType (LIR.TypeVar srcSpan ident) = do
   qualid <- lookupIdentOrFail srcSpan IR.TypeScope (IR.UnQual (IR.Ident ident))
-  return (Coq.Qualid qualid)
-convertType' (IR.TypeCon srcSpan name) = do
+  return $ Coq.Qualid qualid
+convertLiftedType (LIR.TypeCon srcSpan name args _) = do
   qualid <- lookupIdentOrFail srcSpan IR.TypeScope name
-  return (genericApply qualid [] [] [])
-convertType' (IR.TypeApp _ t1 t2) = do
-  t1' <- convertType' t1
-  t2' <- convertType' t2
-  return (Coq.app t1' [t2'])
-convertType' (IR.FuncType _ t1 t2) = do
-  t1' <- convertType t1
-  t2' <- convertType t2
-  return (Coq.Arrow t1' t2')
+  args'  <- mapM convertLiftedType args
+  return $ genericApply qualid [] [] args'
+convertLiftedType (LIR.FuncType _ l r) = do
+  l' <- convertLiftedType l
+  r' <- convertLiftedType r
+  return $ Coq.Arrow l' r'
+convertLiftedType (LIR.FreeTypeCon _ t) = do
+  t' <- convertLiftedType t
+  return $ genericApply Coq.Base.free [] [] [t']


### PR DESCRIPTION
<!--
  Have you read our Code of Conduct?
  By filing an issue or pull request, you are expected to comply with it, including treating everyone with respect:
  https://github.com/FreeProving/guidelines/blob/main/CODE_OF_CONDUCT.md
-->

### Issue
Closes #96.
<!--
  Link to the issue that this pull request addresses.
  If there is not yet a corresponding issue, please open a new issue and then link to that issue in your pull request.
  Give any additional information that is not covered by the linked issue but might be important for the reviewer.
-->

### Description of the Change

Changes the translation of Haskell to Coq types so that the type translation of the lifted IR is used.
<!--
  Give a short summary of the changes you made to handle the issue.
  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
  What process did you follow to verify that your change has the desired effects and has not introduced any regressions?
  Describe the actions you performed (including input you checked, tests you created, commands you ran, etc.), and describe the results you observed.
-->
The existing test suit is used to verify that the type translation is still correct.
### Additional Notes

<!-- Is there anything else worth mentioning (e.g. changes by your PR that other contributors have to be aware of, ideas for further enhancements, etc.)? -->
