### PR TITLE
Implement cbneed (sharing) operator

### DIFF
--- a/base/Free/Malias.v
+++ b/base/Free/Malias.v
@@ -5,24 +5,25 @@ From Base Require Import Free.
 From Base Require Export Free.Instance.Comb.
 From Base Require Export Free.Instance.Share.
 
-(** An operator to model call-by-value evaluation *)
+(* An operator to model call-by-value evaluation *)
 Definition cbv {A : Type} {Shape : Type} {Pos : Shape -> Type} (p : Free Shape Pos A) 
   : Free Shape Pos (Free Shape Pos A) :=
   p >>= fun x => pure (pure x).
 
-(** An operator to model call-by-name evaluation *)
+(* An operator to model call-by-name evaluation *)
 Definition cbn {A : Type} {Shape : Type} {Pos : Shape -> Type}
   (p : Free Shape Pos A) 
   : Free Shape Pos (Free Shape Pos A) := 
   pure p.
 
+(* An operator to model call-by-need evaluation *)
 Definition cbneed {A : Type} {Shape : Type} {Pos : Shape -> Type}
   `{Injectable Share.Shape Share.Pos Shape Pos} (p : Free Shape Pos A)
   : Free Shape Pos (Free Shape Pos A) :=
   Get >>= fun '(i,j) =>
-  Put (i + 1, j) >>
+  Put (i+1,j) >>
   pure (BeginShare (i,j) >>
-      Put (i, j+1) >>
+      Put (i,j+1) >>
       p >>= fun x =>
       Put (i+1,j) >>
       EndShare (i,j) >>

--- a/base/Free/Malias.v
+++ b/base/Free/Malias.v
@@ -20,10 +20,10 @@ Definition cbneed {A : Type} {Shape : Type} {Pos : Shape -> Type}
   `{Injectable Share.Shape Share.Pos Shape Pos} (p : Free Shape Pos A)
   : Free Shape Pos (Free Shape Pos A) :=
   Get >>= fun '(i,j) =>
-  Put (i + 1, j) >>= fun _ =>
-  pure (BeginShare (i,j) >>= fun _ =>
-      Put (i, j+1) >>= fun _ =>
+  Put (i + 1, j) >>
+  pure (BeginShare (i,j) >>
+      Put (i, j+1) >>
       p >>= fun x =>
-      Put (i+1,j) >>= fun _ =>
-      EndShare (i,j) >>= fun _ =>
+      Put (i+1,j) >>
+      EndShare (i,j) >>
       pure x).

--- a/base/Free/Monad.v
+++ b/base/Free/Monad.v
@@ -34,3 +34,4 @@ Arguments impure {Shape} {Pos} {A}.
    introduce the infix notation for the bind operator. *)
 Arguments free_bind {Shape} {Pos} {A} {B}.
 Notation "mx >>= f" := (free_bind mx f) (left associativity, at level 50).
+Notation "mx >> my" := (free_bind mx (fun _ => my)) (left associativity, at level 50).


### PR DESCRIPTION
### Issue

Closes #115 
<!--
  Link to the issue that this pull request addresses.
  If there is not yet a corresponding issue, please open a new issue and then link to that issue in your pull request.
  Give any additional information that is not covered by the linked issue but might be important for the reviewer.
-->

### Description of the Change

This commit adds an operator `cbneed` that models call-by-need evaluation, i.e. non-strict evaluation and sharing. It requires its argument to contain the `Share` effect.

The operator does not support deep sharing yet (sharing inside of the arguments of a shared expression). 
It should eventually be extended to support deep sharing, as well.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

For now, I simply observed the results of various functions that share non-deterministic values using `cbneed` (using a handler). More extensive testing, ideally not just with non-determinism but also other effects that interact with sharing (such as tracing), should definitely be done.

### Additional Notes

<!-- Is there anything else worth mentioning (e.g. changes by your PR that other contributors have to be aware of, ideas for further enhancements, etc.)? -->
