### PR TITLE
Add support for infix data declarations

### DIFF
--- a/src/lib/FreeC/Frontend/Haskell/Simplifier.hs
+++ b/src/lib/FreeC/Frontend/Haskell/Simplifier.hs
@@ -364,8 +364,10 @@ simplifyDeclHead (HSE.DHApp _ declHead typeVarBind) = do
   (declIdent, typeArgs) <- simplifyDeclHead declHead
   typeArg               <- simplifyTypeVarBind typeVarBind
   return (declIdent, typeArgs ++ [typeArg])
-simplifyDeclHead declHead@(HSE.DHInfix _ _ _) =
-  notSupported "Type operators" declHead
+simplifyDeclHead (HSE.DHInfix _ typeVarBind declName) = do
+  typeArg   <- simplifyTypeVarBind typeVarBind
+  declIdent <- simplifyDeclName declName
+  return (declIdent, [typeArg])
 
 -- | Gets the name of a data type or type synonym declaration from the name
 --   stored in the head of the declaration.


### PR DESCRIPTION
<!--
  Have you read our Code of Conduct?
  By filing an issue or pull request, you are expected to comply with it, including treating everyone with respect:
  https://github.com/FreeProving/guidelines/blob/main/CODE_OF_CONDUCT.md
-->

### Issue

<!--
  Link to the issue that this pull request addresses.
  If there is not yet a corresponding issue, please open a new issue and then link to that issue in your pull request.
  Give any additional information that is not covered by the linked issue but might be important for the reviewer.
-->
See https://github.com/FreeProving/haskell-src-transformations/pull/37#discussion_r454998183

### Description of the Change

<!--
  Give a short summary of the changes you made to handle the issue.
  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
-->
Support for infix data type declarations like

```haskell
data a `Foo` b = Bar a b
```

was added to the Haskell front end.

### Verification Process

<!--
  What process did you follow to verify that your change has the desired effects and has not introduced any regressions?
  Describe the actions you performed (including input you checked, tests you created, commands you ran, etc.), and describe the results you observed.
-->
Unfortunately, there are no tests for the Haskell front end. I've tested the implementation with the example above using the `./tool/run.sh` script.

```coq
Inductive Foo (Shape : Type) (Pos : Shape -> Type) (a b : Type) : Type
  := bar : Free Shape Pos a -> Free Shape Pos b -> Foo Shape Pos a b.
```
