### PR TITLE
Add a compiler flag for evaluation strategy selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unrealeased
 
+ - **Added command line option for evaluation strategy selection**
+   + A evaluation strategy can be specified with `--strategy STRAT`.
+   + Changes the behavior of sharing in the translated program.
+
  - **Added command line options for front- and backend selection**
     + A frontend / backend can be specified with `--to LANG` / `--from LANG`.
     + Added IR frontend and backend for debugging purposes.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A compiler for the monadic translation of Haskell programs to Coq that uses the 
         6. [`--version`, `-v`](#--version--v)
         7. [`--help`, `-h`](#--help--h)
         8. [`--from=LANG`, `--to=LANG`](#--fromlang---tolang)
+        9. [`--strategy=STRAT`](#--strategystrat)
     2. [Proving properties](#proving-properties)
     3. [Experimental Features](#experimental-features)
         1. [Pattern-Matching Compilation](#pattern-matching-compilation)
@@ -398,6 +399,13 @@ For example, to print the intermediate representation of a Haskell file, run the
 ```bash
 freec --from haskell --to ir ./example/Data/List.hs
 ```
+
+#### `--strategy=STRAT`
+
+The option selects the evaluation strategy the translated program should use.
+This changes how and if, for example, sharing is handled.
+Currently `cbv`(call-by-value), `cbn`(call-by-name) and `cbneed`(call-by-need) are supported.
+The default strategy is call-by-need.
 
 ### Proving properties
 

--- a/free-compiler.cabal
+++ b/free-compiler.cabal
@@ -125,6 +125,7 @@ library freec-internal
                       , FreeC.Environment.ModuleInterface.Decoder
                       , FreeC.Environment.ModuleInterface.Encoder
                       , FreeC.Environment.Renamer
+                      , FreeC.Environment.Strategy
                       , FreeC.Frontend.Haskell.Parser
                       , FreeC.Frontend.Haskell.PatternMatching
                       , FreeC.Frontend.Haskell.Pretty

--- a/src/exe/FreeC/Application/Options.hs
+++ b/src/exe/FreeC/Application/Options.hs
@@ -41,6 +41,8 @@ data Options = Options
     -- ^ The frontend to use.
   , optBackend                   :: String
     -- ^ The backend to use.
+  , optStrategy                  :: String
+    -- ^ The evalutation strategy to use.
   }
 
 -- | The default command line options.
@@ -68,4 +70,5 @@ makeDefaultOptions = do
     , optDumpTransformedModulesDir = Nothing
     , optFrontend                  = defaultFrontend
     , optBackend                   = defaultBackend
+    , optStrategy                  = "cbn"
     }

--- a/src/exe/FreeC/Application/Options.hs
+++ b/src/exe/FreeC/Application/Options.hs
@@ -2,9 +2,10 @@
 --   that stores the values of the command line options.
 module FreeC.Application.Options ( Options(..), makeDefaultOptions ) where
 
-import           Paths_free_compiler ( getDataFileName )
+import           Paths_free_compiler        ( getDataFileName )
 
 import {-# SOURCE #-} FreeC.Backend
+import           FreeC.Environment.Strategy
 import {-# SOURCE #-} FreeC.Frontend
 
 -- | Data type that stores the command line options passed to the compiler.
@@ -70,5 +71,5 @@ makeDefaultOptions = do
     , optDumpTransformedModulesDir = Nothing
     , optFrontend                  = defaultFrontend
     , optBackend                   = defaultBackend
-    , optStrategy                  = "cbn"
+    , optStrategy                  = defaultStrategy
     }

--- a/src/exe/FreeC/Application/Options.hs
+++ b/src/exe/FreeC/Application/Options.hs
@@ -71,5 +71,6 @@ makeDefaultOptions = do
     , optDumpTransformedModulesDir = Nothing
     , optFrontend                  = defaultFrontend
     , optBackend                   = defaultBackend
-    , optStrategy                  = defaultStrategy
+    , optStrategy                  = let (opt, _, _) = defaultStrategy
+                                     in opt
     }

--- a/src/exe/FreeC/Application/Options/Descriptors.hs
+++ b/src/exe/FreeC/Application/Options/Descriptors.hs
@@ -86,6 +86,8 @@ optionDescriptors
         (unlines [ "Optional. Specifies which evaluation strategy the resulting"
                  , "program will use. Allowed values are: "
                  , showStrategies ++ "."
-                 , "Defaults to `" ++ defaultStrategy ++ "`."
+                 , "Defaults to `"
+                     ++ let (opt, _, _) = defaultStrategy
+                        in opt ++ "`."
                  ])
     ]

--- a/src/exe/FreeC/Application/Options/Descriptors.hs
+++ b/src/exe/FreeC/Application/Options/Descriptors.hs
@@ -7,6 +7,7 @@ import           System.Console.GetOpt
 
 import           FreeC.Application.Options
 import           FreeC.Backend
+import           FreeC.Environment.Strategy
 import           FreeC.Frontend
 
 -- | The command line option descriptors from the @GetOpt@ library for the
@@ -82,10 +83,9 @@ optionDescriptors
                  ])
     , Option [] ["strategy"]
         (ReqArg (\p opts -> opts { optStrategy = p }) "STRAT")
-        (unlines
-         [ "Optional. Specifies which evaluation strategy"
-         , "the resulting program will use."
-         , "Allowed values are: `cbn`(call-by-need/name) and `cbv`(call-by-value)."
-         , "Defaults to `cbn`."
-         ])
+        (unlines [ "Optional. Specifies which evaluation strategy the resulting"
+                 , "program will use. Allowed values are: "
+                 , showStrategies ++ "."
+                 , "Defaults to `" ++ defaultStrategy ++ "`."
+                 ])
     ]

--- a/src/exe/FreeC/Application/Options/Descriptors.hs
+++ b/src/exe/FreeC/Application/Options/Descriptors.hs
@@ -80,4 +80,12 @@ optionDescriptors
                  , "Allowed values are: " ++ showBackends ++ "."
                  , "Defaults to: `" ++ defaultBackend ++ "`."
                  ])
+    , Option [] ["strategy"]
+        (ReqArg (\p opts -> opts { optStrategy = p }) "STRAT")
+        (unlines
+         [ "Optional. Specifies which evaluation strategy"
+         , "the resulting program will use."
+         , "Allowed values are: `cbn`(call-by-need/name) and `cbv`(call-by-value)."
+         , "Defaults to `cbn`."
+         ])
     ]

--- a/src/exe/Main.hs
+++ b/src/exe/Main.hs
@@ -21,6 +21,7 @@ import           FreeC.Backend
 import           FreeC.Environment
 import           FreeC.Environment.ModuleInterface.Decoder
 import           FreeC.Environment.ModuleInterface.Encoder
+import           FreeC.Environment.Strategy
 import           FreeC.Frontend
 import qualified FreeC.IR.Base.Prelude                     as IR.Prelude
 import qualified FreeC.IR.Base.Test.QuickCheck             as IR.Test.QuickCheck
@@ -112,6 +113,21 @@ selectBackend = do
         ++ showBackends
         ++ "."
     Just b  -> return b
+
+-------------------------------------------------------------------------------
+-- Strategy Selection                                                        --
+-------------------------------------------------------------------------------
+-- | Selects the correct evaluation strategy and adds it to the environment or
+--   throws an error if such a strategy does not exist.
+selectStrategy :: Application ()
+selectStrategy = do
+  name <- inOpts optStrategy
+  case Map.lookup name strategies of
+    Nothing    -> reportFatal
+      $ Message NoSrcSpan Error
+      $ "Unrecognized evaluation strategy."
+      ++ "Allowed values are `cbn`(call-by-name/need) and `cbv`(call-by-value)."
+    Just strat -> modifyEnv $ changeStrategy strat
 
 -------------------------------------------------------------------------------
 -- Input Files                                                               --

--- a/src/exe/Main.hs
+++ b/src/exe/Main.hs
@@ -69,9 +69,11 @@ compiler = do
     putDebug "No input file.\n"
     putUsageInfo
     exitSuccess
-  -- Select frontend and backend
+  -- Select frontend and backend.
   frontend <- selectFrontend
   backend <- selectBackend
+  -- Select evaluation strategy.
+  selectStrategy
   -- Initialize environment.
   loadPrelude
   loadQuickCheck
@@ -122,11 +124,13 @@ selectBackend = do
 selectStrategy :: Application ()
 selectStrategy = do
   name <- inOpts optStrategy
-  case Map.lookup name strategies of
+  case Map.lookup name strategyMap of
     Nothing    -> reportFatal
       $ Message NoSrcSpan Error
       $ "Unrecognized evaluation strategy."
-      ++ "Allowed values are `cbn`(call-by-name/need) and `cbv`(call-by-value)."
+      ++ "Allowed values are: "
+      ++ showStrategies
+      ++ "."
     Just strat -> modifyEnv $ changeStrategy strat
 
 -------------------------------------------------------------------------------

--- a/src/lib/FreeC/Environment.hs
+++ b/src/lib/FreeC/Environment.hs
@@ -87,7 +87,7 @@ emptyEnv = Environment   -- Modules
   , envEntries          = Map.empty
   , envDecArgs          = Map.empty
   , envFreshIdentCount  = Map.empty
-  , envStrategy         = CallByNameOrNeed
+  , envStrategy         = undefined -- always set before evaluation
   }
 
 -------------------------------------------------------------------------------

--- a/src/lib/FreeC/Environment.hs
+++ b/src/lib/FreeC/Environment.hs
@@ -38,6 +38,7 @@ module FreeC.Environment
   , lookupDecArg
   , lookupDecArgIndex
   , lookupDecArgIdent
+  , changeStrategy
   ) where
 
 import           Data.Composition                  ( (.:), (.:.) )
@@ -51,6 +52,7 @@ import qualified FreeC.Backend.Agda.Syntax         as Agda
 import qualified FreeC.Backend.Coq.Syntax          as Coq
 import           FreeC.Environment.Entry
 import           FreeC.Environment.ModuleInterface
+import           FreeC.Environment.Strategy
 import           FreeC.IR.SrcSpan
 import qualified FreeC.IR.Syntax                   as IR
 import           FreeC.Util.Predicate
@@ -71,6 +73,8 @@ data Environment = Environment
   , envFreshIdentCount  :: Map String Int
     -- ^ The number of fresh identifiers that were used in the environment
     --   with a certain prefix.
+  , envStrategy         :: Strategy
+    -- ^ The evaluation strategy selected by the user.
   }
  deriving Show
 
@@ -83,6 +87,7 @@ emptyEnv = Environment   -- Modules
   , envEntries          = Map.empty
   , envDecArgs          = Map.empty
   , envFreshIdentCount  = Map.empty
+  , envStrategy         = CallByNameOrNeed
   }
 
 -------------------------------------------------------------------------------
@@ -307,3 +312,10 @@ lookupDecArgIndex = fmap fst .: lookupDecArg
 -- | Like 'lookupDecArg' but returns the decreasing argument's name only.
 lookupDecArgIdent :: IR.QName -> Environment -> Maybe String
 lookupDecArgIdent = fmap snd .: lookupDecArg
+
+-------------------------------------------------------------------------------
+-- Changing the Strategy in the Environment                                  --
+-------------------------------------------------------------------------------
+-- | Changes the strategy in the environment to the given strategy.
+changeStrategy :: Strategy -> Environment -> Environment
+changeStrategy strat env = env { envStrategy = strat }

--- a/src/lib/FreeC/Environment.hs
+++ b/src/lib/FreeC/Environment.hs
@@ -15,6 +15,7 @@ module FreeC.Environment
   , removeDecArg
     -- * Modifying Entries in the Environment
   , modifyEntryIdent
+  , changeStrategy
     -- * Looking up Entries from the Environment
   , lookupEntry
   , isFunction
@@ -38,7 +39,6 @@ module FreeC.Environment
   , lookupDecArg
   , lookupDecArgIndex
   , lookupDecArgIdent
-  , changeStrategy
   ) where
 
 import           Data.Composition                  ( (.:), (.:.) )
@@ -145,6 +145,10 @@ modifyEntryIdent
 modifyEntryIdent scope name newIdent env = case lookupEntry scope name env of
   Nothing    -> env
   Just entry -> addEntry (entry { entryIdent = newIdent }) env
+
+-- | Changes the strategy in the environment to the given strategy.
+changeStrategy :: Strategy -> Environment -> Environment
+changeStrategy strat env = env { envStrategy = strat }
 
 -------------------------------------------------------------------------------
 -- Looking up Entries from the Environment                                   --
@@ -312,10 +316,3 @@ lookupDecArgIndex = fmap fst .: lookupDecArg
 -- | Like 'lookupDecArg' but returns the decreasing argument's name only.
 lookupDecArgIdent :: IR.QName -> Environment -> Maybe String
 lookupDecArgIdent = fmap snd .: lookupDecArg
-
--------------------------------------------------------------------------------
--- Changing the Strategy in the Environment                                  --
--------------------------------------------------------------------------------
--- | Changes the strategy in the environment to the given strategy.
-changeStrategy :: Strategy -> Environment -> Environment
-changeStrategy strat env = env { envStrategy = strat }

--- a/src/lib/FreeC/Environment.hs
+++ b/src/lib/FreeC/Environment.hs
@@ -87,7 +87,8 @@ emptyEnv = Environment   -- Modules
   , envEntries          = Map.empty
   , envDecArgs          = Map.empty
   , envFreshIdentCount  = Map.empty
-  , envStrategy         = undefined -- always set before evaluation
+  , envStrategy         = let (_, _, strat) = defaultStrategy
+                          in strat
   }
 
 -------------------------------------------------------------------------------

--- a/src/lib/FreeC/Environment/Strategy.hs
+++ b/src/lib/FreeC/Environment/Strategy.hs
@@ -4,12 +4,39 @@
 --   into the environment. It determines how the @share@ operator behaves.
 module FreeC.Environment.Strategy where
 
-import           Data.Map.Strict
+import           Data.List       ( intercalate )
+import           Data.Map.Strict ( Map, fromList )
 
 -- | The data type for an evaluation strategy.
-data Strategy = CallByValue | CallByNameOrNeed
+data Strategy = CallByValue | CallByName | CallByNeed
  deriving Show
 
--- | A map of all strategies with their option name as keys.
-strategies :: Map String Strategy
-strategies = fromList [("cbv", CallByValue), ("cbn", CallByNameOrNeed)]
+-- | The option value, name and strategy of call-by-value.
+callByValue :: (String, String, Strategy)
+callByValue = ("cbv", "call-by-value", CallByValue)
+
+-- | The option value, name and strategy of call-by-name.
+callByName :: (String, String, Strategy)
+callByName = ("cbn", "call-by-name", CallByName)
+
+-- | The option value, name and strategy of call-by-need.
+callByNeed :: (String, String, Strategy)
+callByNeed = ("cbneed", "call-by-need", CallByNeed)
+
+-- | A list of all strategies.
+strategies :: [(String, String, Strategy)]
+strategies = [callByValue, callByName, callByNeed]
+
+-- | The option value of the default strategy.
+defaultStrategy :: String
+defaultStrategy = let (opt, _, _) = callByNeed
+                  in opt
+
+-- | Show all strategies with their option value and name.
+showStrategies :: String
+showStrategies = intercalate ", "
+  $ map (\(opt, name, _) -> "`" ++ opt ++ "`(" ++ name ++ ")") strategies
+
+-- | A map of all strategies with their option as keys.
+strategyMap :: Map String Strategy
+strategyMap = fromList $ [(opt, strat) | (opt, _, strat) <- strategies]

--- a/src/lib/FreeC/Environment/Strategy.hs
+++ b/src/lib/FreeC/Environment/Strategy.hs
@@ -1,0 +1,15 @@
+-- | This module contains a data type for an evaluation strategy.
+--
+--   This strategy is decided by the user as an command line option and passed
+--   into the environment. It determines how the @share@ operator behaves.
+module FreeC.Environment.Strategy where
+
+import           Data.Map.Strict
+
+-- | The data type for an evaluation strategy.
+data Strategy = CallByValue | CallByNameOrNeed
+ deriving Show
+
+-- | A map of all strategies with their option name as keys.
+strategies :: Map String Strategy
+strategies = fromList [("cbv", CallByValue), ("cbn", CallByNameOrNeed)]

--- a/src/lib/FreeC/Environment/Strategy.hs
+++ b/src/lib/FreeC/Environment/Strategy.hs
@@ -27,16 +27,15 @@ callByNeed = ("cbneed", "call-by-need", CallByNeed)
 strategies :: [(String, String, Strategy)]
 strategies = [callByValue, callByName, callByNeed]
 
--- | The option value of the default strategy.
-defaultStrategy :: String
-defaultStrategy = let (opt, _, _) = callByNeed
-                  in opt
+-- | The option value, name and strategy of the default strategy.
+defaultStrategy :: (String, String, Strategy)
+defaultStrategy = callByNeed
 
 -- | Show all strategies with their option value and name.
 showStrategies :: String
 showStrategies = intercalate ", "
   $ map (\(opt, name, _) -> "`" ++ opt ++ "`(" ++ name ++ ")") strategies
 
--- | A map of all strategies with their option as keys.
+-- | A map of all strategies with their option values as keys.
 strategyMap :: Map String Strategy
 strategyMap = fromList $ [(opt, strat) | (opt, _, strat) <- strategies]


### PR DESCRIPTION
<!--
  Have you read our Code of Conduct?
  By filing an issue or pull request, you are expected to comply with it, including treating everyone with respect:
  https://github.com/FreeProving/guidelines/blob/main/CODE_OF_CONDUCT.md
-->

### Issue
Closes #168.
<!--
  Link to the issue that this pull request addresses.
  If there is not yet a corresponding issue, please open a new issue and then link to that issue in your pull request.
  Give any additional information that is not covered by the linked issue but might be important for the reviewer.
-->

### Description of the Change
Adds a compiler option `--strategy STRAT` to allow the user to select a evaluation strategy. This strategy will change the behaviour of the `share` operator that is to be implemented. Implements a call-by-value and a call-by-need/name strategy.  
<!--
  Give a short summary of the changes you made to handle the issue.
  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
  What process did you follow to verify that your change has the desired effects and has not introduced any regressions?
  Describe the actions you performed (including input you checked, tests you created, commands you ran, etc.), and describe the results you observed.
-->

### Additional Notes

<!-- Is there anything else worth mentioning (e.g. changes by your PR that other contributors have to be aware of, ideas for further enhancements, etc.)? -->
