### PR TITLE
Add tests for the definition of smart constructors as notations

### DIFF
--- a/base/coq/Free/Verification/NormalizationTests.v
+++ b/base/coq/Free/Verification/NormalizationTests.v
@@ -373,7 +373,7 @@ Proof. constructor. Qed.
 (* [[true,trace "component effect" false]]
    --> ([[true,false]],["component effect"]) *)
 Example deepEffectTracing : evalTracingNF deepTraceList
- = (List.cons ((List.Cons IdS IdP (True_ IdS IdP) 
+ = (List.cons ((Cons IdS IdP (True_ IdS IdP) 
                                  (Cons IdS IdP (False_ IdS IdP) 
                                                (Nil IdS IdP)))) 
               (Nil IdS IdP),
@@ -382,11 +382,11 @@ Proof. constructor. Qed.
 
 (* [[true, true ? false]] --> [[[true,true]],[[true,false]]] *)
 Example deepEffectND : evalNDNF deepCoinList
- = [List.cons ((List.Cons IdS IdP (True_ IdS IdP) 
+ = [List.cons ((Cons IdS IdP (True_ IdS IdP) 
                                   (Cons IdS IdP (True_ IdS IdP) 
                                                 (Nil IdS IdP)))) 
                (Nil IdS IdP);
-    List.cons ((List.Cons IdS IdP (True_ IdS IdP) 
+    List.cons ((Cons IdS IdP (True_ IdS IdP) 
                                   (Cons IdS IdP (False_ IdS IdP) 
                                                 (Nil IdS IdP)))) 
                (Nil IdS IdP)

--- a/base/coq/Free/Verification/NormalizationTests.v
+++ b/base/coq/Free/Verification/NormalizationTests.v
@@ -338,7 +338,7 @@ Proof. constructor. Qed.
    --> ([true,false], ["root effect", "component effect"])*)
 Example rootAndComponentEffectTracing : evalTracingNF tracedTraceList
  = (List.cons (True_ IdS IdP) 
-              (List.Cons IdS IdP (False_ IdS IdP) (Nil IdS IdP)),
+              (Cons IdS IdP (False_ IdS IdP) (Nil IdS IdP)),
     ["root effect"%string; "component effect"%string]).
 Proof. constructor. Qed.
 

--- a/base/coq/Free/Verification/SharingHandlerTests.v
+++ b/base/coq/Free/Verification/SharingHandlerTests.v
@@ -67,11 +67,11 @@ Section SecData.
   (* [0 ? 1, 2 ? 3] *)
   Definition coinList `{ND}
   : Free Shape Pos (List Shape Pos (Integer Shape Pos))
-  := List.Cons Shape Pos 
+  := Cons Shape Pos 
        (Choice Shape Pos (pure 0%Z) (pure 1%Z))
-       (List.Cons Shape Pos 
+       (Cons Shape Pos 
          (Choice Shape Pos (pure 2%Z) (pure 3%Z))
-         (List.Nil Shape Pos)).
+         (Nil Shape Pos)).
 
 
   (* Traced integer. *)
@@ -97,11 +97,11 @@ Section SecData.
   (* [trace "0" 0, trace "1" 1] *)
   Definition traceList `{Trace}
   : Free Shape Pos (List Shape Pos (Integer Shape Pos))
-  := List.Cons Shape Pos 
+  := Cons Shape Pos 
        (trace "0" (pure 0%Z))
-       (List.Cons Shape Pos 
+       (Cons Shape Pos 
          (trace "1" (pure 2%Z))
-         (List.Nil Shape Pos)).
+         (Nil Shape Pos)).
 
 End SecData.
 

--- a/free-compiler.cabal
+++ b/free-compiler.cabal
@@ -230,6 +230,7 @@ test-suite freec-unit-tests
                     , FreeC.Backend.Coq.Converter.FuncDecl.RecTests
                     , FreeC.Backend.Coq.Converter.FuncDecl.Rec.WithHelpersTests
                     , FreeC.Backend.Coq.Converter.FuncDecl.Rec.WithSectionsTests
+                    , FreeC.Backend.Coq.Converter.ModuleTests
                     , FreeC.Backend.Coq.Converter.TypeDeclTests
                     , FreeC.Backend.Coq.Converter.TypeTests
                     , FreeC.Backend.Coq.Tests

--- a/src/test/FreeC/Backend/Coq/Converter/ModuleTests.hs
+++ b/src/test/FreeC/Backend/Coq/Converter/ModuleTests.hs
@@ -1,0 +1,195 @@
+-- | This module contains tests for "FreeC.Backend.Coq.Converter.Module".
+module FreeC.Backend.Coq.Converter.ModuleTests ( testConvertModule ) where
+
+import           Test.Hspec
+
+import           FreeC.Backend.Coq.Converter.Module
+import           FreeC.Backend.Coq.Pretty           ()
+import           FreeC.Monad.Class.Testable
+import           FreeC.Monad.Converter
+import           FreeC.Test.Environment
+import           FreeC.Test.Expectations
+import           FreeC.Test.Parser
+
+-------------------------------------------------------------------------------
+-- Expectation Setters                                                       --
+-------------------------------------------------------------------------------
+-- | Parses the given IR module, converts it to Coq using
+--   'convertModule' and sets the expectation that the resulting AST
+--   is equal to the given output when pretty printed modulo whitespace.
+shouldConvertModuleTo :: [String] -> String -> Converter Expectation
+shouldConvertModuleTo inputStrs expectedOutputStr = do
+  input <- parseTestModule inputStrs
+  output <- convertModule input
+  return (output `prettyShouldBe` expectedOutputStr)
+
+-- | Test group for 'convertModule' tests.
+testConvertModule :: Spec
+testConvertModule = describe "FreeC.Backend.Coq.Converter.Module"
+  $ context "Generation of qualified notations"
+  $ do
+    it "translates empty modules correctly"
+      $ shouldSucceedWith
+      $ do
+        shouldConvertModuleTo ["module A where"]
+      $ "(* module A *) From Base Require Import Free. "
+      ++ "(* Qualified smart constructors *) "
+      ++ "Module QualifiedSmartConstructorModule. "
+      ++ "End QualifiedSmartConstructorModule. "
+    it "produces notations for a single type correctly" $ shouldSucceedWith $ do
+      _ <- defineTestTypeCon "A.Foo" 0 ["A.Bar"]
+      _ <- defineTestCon "A.Bar" 0 "A.Foo"
+      shouldConvertModuleTo ["module A where", "data A.Foo = A.Bar"]
+        $ "(* module A *) "
+        ++ "From Base Require Import Free. "
+        ++ "(* Data type declarations for Foo *) "
+        ++ "Inductive Foo (Shape : Type) (Pos : Shape -> Type) : Type "
+        ++ ":= bar : Foo Shape Pos. "
+        ++ "(* Arguments sentences for Foo *) "
+        ++ "Arguments bar {Shape} {Pos}. "
+        ++ "(* Smart constructors for Foo *) "
+        ++ "Notation \"'Bar' Shape Pos\" := "
+        ++ "(@pure Shape Pos (Foo Shape Pos) (@bar Shape Pos)) "
+        ++ "( at level 10, Shape, Pos at level 9 ). "
+        ++ "Notation \"'@Bar' Shape Pos\" := "
+        ++ "(@pure Shape Pos (Foo Shape Pos) (@bar Shape Pos)) "
+        ++ "( only parsing, at level 10, Shape, Pos at level 9 ). "
+        ++ "(* Qualified smart constructors *) "
+        ++ "Module QualifiedSmartConstructorModule. "
+        ++ "(* Qualified smart constructors for Foo *) "
+        ++ "Notation \"'A.Bar' Shape Pos\" := "
+        ++ "(@pure Shape Pos (Foo Shape Pos) (@bar Shape Pos)) "
+        ++ "( at level 10, Shape, Pos at level 9 ). "
+        ++ "Notation \"'@A.Bar' Shape Pos\" := "
+        ++ "(@pure Shape Pos (Foo Shape Pos) (@bar Shape Pos)) "
+        ++ "( only parsing, at level 10, Shape, Pos at level 9 ). "
+        ++ "End QualifiedSmartConstructorModule. "
+    it "produces notations for polymorphic types correctly"
+      $ shouldSucceedWith
+      $ do
+        _ <- defineTestTypeCon "A.Foo" 0 ["A.Bar", "A.Baz"]
+        _ <- defineTestCon "A.Bar" 0 "A.Foo"
+        _ <- defineTestCon "A.Baz" 0 "A.Foo"
+        shouldConvertModuleTo ["module A where", "data A.Foo = A.Bar | A.Baz"]
+          $ "(* module A *) "
+          ++ "From Base Require Import Free. "
+          ++ "(* Data type declarations for Foo *) "
+          ++ "Inductive Foo (Shape : Type) (Pos : Shape -> Type) : Type "
+          ++ ":= bar : Foo Shape Pos | baz : Foo Shape Pos. "
+          ++ "(* Arguments sentences for Foo *) "
+          ++ "Arguments bar {Shape} {Pos}. "
+          ++ "Arguments baz {Shape} {Pos}. "
+          ++ "(* Smart constructors for Foo *) "
+          ++ "Notation \"'Bar' Shape Pos\" := "
+          ++ "(@pure Shape Pos (Foo Shape Pos) (@bar Shape Pos)) "
+          ++ "( at level 10, Shape, Pos at level 9 ). "
+          ++ "Notation \"'@Bar' Shape Pos\" := "
+          ++ "(@pure Shape Pos (Foo Shape Pos) (@bar Shape Pos)) "
+          ++ "( only parsing, at level 10, Shape, Pos at level 9 ). "
+          ++ "Notation \"'Baz' Shape Pos\" := "
+          ++ "(@pure Shape Pos (Foo Shape Pos) (@baz Shape Pos)) "
+          ++ "( at level 10, Shape, Pos at level 9 ). "
+          ++ "Notation \"'@Baz' Shape Pos\" := "
+          ++ "(@pure Shape Pos (Foo Shape Pos) (@baz Shape Pos)) "
+          ++ "( only parsing, at level 10, Shape, Pos at level 9 ). "
+          ++ "(* Qualified smart constructors *) "
+          ++ "Module QualifiedSmartConstructorModule. "
+          ++ "(* Qualified smart constructors for Foo *) "
+          ++ "Notation \"'A.Bar' Shape Pos\" := "
+          ++ "(@pure Shape Pos (Foo Shape Pos) (@bar Shape Pos)) "
+          ++ "( at level 10, Shape, Pos at level 9 ). "
+          ++ "Notation \"'@A.Bar' Shape Pos\" := "
+          ++ "(@pure Shape Pos (Foo Shape Pos) (@bar Shape Pos)) "
+          ++ "( only parsing, at level 10, Shape, Pos at level 9 ). "
+          ++ "Notation \"'A.Baz' Shape Pos\" := "
+          ++ "(@pure Shape Pos (Foo Shape Pos) (@baz Shape Pos)) "
+          ++ "( at level 10, Shape, Pos at level 9 ). "
+          ++ "Notation \"'@A.Baz' Shape Pos\" := "
+          ++ "(@pure Shape Pos (Foo Shape Pos) (@baz Shape Pos)) "
+          ++ "( only parsing, at level 10, Shape, Pos at level 9 ). "
+          ++ "End QualifiedSmartConstructorModule. "
+    it "produces notations for a type with two constructors correctly"
+      $ shouldSucceedWith
+      $ do
+        _ <- defineTestTypeCon "A.Foo" 1 ["A.Bar"]
+        _ <- defineTestCon "A.Bar" 1 "forall a. a -> A.Foo a"
+        shouldConvertModuleTo ["module A where", "data A.Foo a = A.Bar a"]
+          $ "(* module A *) "
+          ++ "From Base Require Import Free. "
+          ++ "(* Data type declarations for Foo *) "
+          ++ "Inductive Foo (Shape : Type) (Pos : Shape -> Type) "
+          ++ "(a : Type) : Type "
+          ++ ":= bar : Free Shape Pos a -> Foo Shape Pos a. "
+          ++ "(* Arguments sentences for Foo *) "
+          ++ "Arguments bar {Shape} {Pos} {a}. "
+          ++ "(* Smart constructors for Foo *) "
+          ++ "Notation \"'Bar' Shape Pos x_0\" := "
+          ++ "(@pure Shape Pos (Foo Shape Pos _) (@bar Shape Pos _ x_0)) "
+          ++ "( at level 10, Shape, Pos, x_0 at level 9 ). "
+          ++ "Notation \"'@Bar' Shape Pos a x_0\" := "
+          ++ "(@pure Shape Pos (Foo Shape Pos a) (@bar Shape Pos a x_0)) "
+          ++ "( only parsing, at level 10, Shape, Pos, a, x_0 "
+          ++ "at level 9 ). "
+          ++ "(* Qualified smart constructors *) "
+          ++ "Module QualifiedSmartConstructorModule. "
+          ++ "(* Qualified smart constructors for Foo *) "
+          ++ "Notation \"'A.Bar' Shape Pos x_0\" := "
+          ++ "(@pure Shape Pos (Foo Shape Pos _) (@bar Shape Pos _ x_0)) "
+          ++ "( at level 10, Shape, Pos, x_0 at level 9 ). "
+          ++ "Notation \"'@A.Bar' Shape Pos a x_0\" := "
+          ++ "(@pure Shape Pos (Foo Shape Pos a) (@bar Shape Pos a x_0)) "
+          ++ "( only parsing, at level 10, Shape, Pos, a, x_0 "
+          ++ "at level 9 ). "
+          ++ "End QualifiedSmartConstructorModule. "
+    it "produces notations for two data type declarations correctly"
+      $ shouldSucceedWith
+      $ do
+        _ <- defineTestTypeCon "A.Foo1" 0 ["A.Bar1"]
+        _ <- defineTestTypeCon "A.Foo2" 0 ["A.Bar2"]
+        _ <- defineTestCon "A.Bar1" 0 "A.Foo1"
+        _ <- defineTestCon "A.Bar2" 0 "A.Foo2"
+        shouldConvertModuleTo
+          ["module A where", "data A.Foo1 = A.Bar1;", "data A.Foo2 = A.Bar2"]
+          $ "(* module A *) "
+          ++ "From Base Require Import Free. "
+          ++ "(* Data type declarations for Foo2 *) "
+          ++ "Inductive Foo2 (Shape : Type) (Pos : Shape -> Type) : Type "
+          ++ ":= bar2 : Foo2 Shape Pos. "
+          ++ "(* Arguments sentences for Foo2 *) "
+          ++ "Arguments bar2 {Shape} {Pos}. "
+          ++ "(* Smart constructors for Foo2 *) "
+          ++ "Notation \"'Bar2' Shape Pos\" := "
+          ++ "(@pure Shape Pos (Foo2 Shape Pos) (@bar2 Shape Pos)) "
+          ++ "( at level 10, Shape, Pos at level 9 ). "
+          ++ "Notation \"'@Bar2' Shape Pos\" := "
+          ++ "(@pure Shape Pos (Foo2 Shape Pos) (@bar2 Shape Pos)) "
+          ++ "( only parsing, at level 10, Shape, Pos at level 9 ). "
+          ++ "(* Data type declarations for Foo1 *) "
+          ++ "Inductive Foo1 (Shape : Type) (Pos : Shape -> Type) : Type "
+          ++ ":= bar1 : Foo1 Shape Pos. "
+          ++ "(* Arguments sentences for Foo1 *) "
+          ++ "Arguments bar1 {Shape} {Pos}. "
+          ++ "(* Smart constructors for Foo1 *) "
+          ++ "Notation \"'Bar1' Shape Pos\" := "
+          ++ "(@pure Shape Pos (Foo1 Shape Pos) (@bar1 Shape Pos)) "
+          ++ "( at level 10, Shape, Pos at level 9 ). "
+          ++ "Notation \"'@Bar1' Shape Pos\" := "
+          ++ "(@pure Shape Pos (Foo1 Shape Pos) (@bar1 Shape Pos)) "
+          ++ "( only parsing, at level 10, Shape, Pos at level 9 ). "
+          ++ "(* Qualified smart constructors *) "
+          ++ "Module QualifiedSmartConstructorModule. "
+          ++ "(* Qualified smart constructors for Foo2 *) "
+          ++ "Notation \"'A.Bar2' Shape Pos\" := "
+          ++ "(@pure Shape Pos (Foo2 Shape Pos) (@bar2 Shape Pos)) "
+          ++ "( at level 10, Shape, Pos at level 9 ). "
+          ++ "Notation \"'@A.Bar2' Shape Pos\" := "
+          ++ "(@pure Shape Pos (Foo2 Shape Pos) (@bar2 Shape Pos)) "
+          ++ "( only parsing, at level 10, Shape, Pos at level 9 ). "
+          ++ "(* Qualified smart constructors for Foo1 *) "
+          ++ "Notation \"'A.Bar1' Shape Pos\" := "
+          ++ "(@pure Shape Pos (Foo1 Shape Pos) (@bar1 Shape Pos)) "
+          ++ "( at level 10, Shape, Pos at level 9 ). "
+          ++ "Notation \"'@A.Bar1' Shape Pos\" := "
+          ++ "(@pure Shape Pos (Foo1 Shape Pos) (@bar1 Shape Pos)) "
+          ++ "( only parsing, at level 10, Shape, Pos at level 9 ). "
+          ++ "End QualifiedSmartConstructorModule. "

--- a/src/test/FreeC/Backend/Coq/Converter/ModuleTests.hs
+++ b/src/test/FreeC/Backend/Coq/Converter/ModuleTests.hs
@@ -61,7 +61,7 @@ testConvertModule = describe "FreeC.Backend.Coq.Converter.Module"
         ++ "(@pure Shape Pos (Foo Shape Pos) (@bar Shape Pos)) "
         ++ "( only parsing, at level 10, Shape, Pos at level 9 ). "
         ++ "End QualifiedSmartConstructorModule. "
-    it "produces notations for polymorphic types correctly"
+    it "produces notations for a type with two constructors correctly"
       $ shouldSucceedWith
       $ do
         _ <- defineTestTypeCon "A.Foo" 0 ["A.Bar", "A.Baz"]
@@ -105,7 +105,7 @@ testConvertModule = describe "FreeC.Backend.Coq.Converter.Module"
           ++ "(@pure Shape Pos (Foo Shape Pos) (@baz Shape Pos)) "
           ++ "( only parsing, at level 10, Shape, Pos at level 9 ). "
           ++ "End QualifiedSmartConstructorModule. "
-    it "produces notations for a type with two constructors correctly"
+    it "produces notations for polymorphic types correctly"
       $ shouldSucceedWith
       $ do
         _ <- defineTestTypeCon "A.Foo" 1 ["A.Bar"]

--- a/src/test/FreeC/Backend/Coq/Converter/ModuleTests.hs
+++ b/src/test/FreeC/Backend/Coq/Converter/ModuleTests.hs
@@ -33,9 +33,6 @@ testConvertModule = describe "FreeC.Backend.Coq.Converter.Module"
       $ do
         shouldConvertModuleTo ["module A where"]
       $ "(* module A *) From Base Require Import Free. "
-      ++ "(* Qualified smart constructors *) "
-      ++ "Module QualifiedSmartConstructorModule. "
-      ++ "End QualifiedSmartConstructorModule. "
     it "produces notations for a single type correctly" $ shouldSucceedWith $ do
       _ <- defineTestTypeCon "A.Foo" 0 ["A.Bar"]
       _ <- defineTestCon "A.Bar" 0 "A.Foo"

--- a/src/test/FreeC/Backend/Coq/ConverterTests.hs
+++ b/src/test/FreeC/Backend/Coq/ConverterTests.hs
@@ -5,6 +5,7 @@ import           Test.Hspec
 
 import           FreeC.Backend.Coq.Converter.ExprTests
 import           FreeC.Backend.Coq.Converter.FuncDeclTests
+import           FreeC.Backend.Coq.Converter.ModuleTests
 import           FreeC.Backend.Coq.Converter.TypeDeclTests
 import           FreeC.Backend.Coq.Converter.TypeTests
 
@@ -14,5 +15,6 @@ testConverter = do
   testConvertDataDecls
   testConvertExpr
   testConvertFuncDecl
+  testConvertModule
   testConvertType
   testConvertTypeDecl


### PR DESCRIPTION
In order to test the generation of modules for qualified notations, a test suite for the conversion of modules has been added.

### Issue

Tests for #153

### Description of the Change

A new module `FreeC.Backend.Coq.Converter.ModuleTests` has been added that tests the translation of entire modules.
Since a module for qualified notations is added to each module not on a type level, but a module level, the translation of the entire module is tested to check that the notation module is generated correctly.
