### PR TITLE
Allow aliases in decreasing arguments analysis

### DIFF
--- a/src/lib/FreeC/Backend/Coq/Analysis/DecreasingArguments.hs
+++ b/src/lib/FreeC/Backend/Coq/Analysis/DecreasingArguments.hs
@@ -34,23 +34,42 @@
 --   > g e₁ … eⱼ … eₘ
 --
 --   where @j@ is the decreasing argument guessed for @g@ the expression
---   @eⱼ@ is recognizes as structurally smaller than @xᵢ@.
+--   @eⱼ@ is recognized as structurally smaller than @xᵢ@.
 --
 --   == Checking for Structurally Smaller Expressions
 --
---   Within a function for whose decreasing argument we've guessed @xᵢ@ a
---   variable @x@ is structurally smaller than @xᵢ@ if one of the following
---   two conditions is met.
+--   To test whether an expression is structurally smaller than the decreasing
+--   argument, we assign every expression a depth within the structure of the
+--   decreasing argument as described below. There is a special depth value @⊥@
+--   with the property @⊥ + 1 = ⊥@ that is assigned to expressions that are not
+--   known to be subterms of the decreasing argument.
 --
---   1. @x@ is bound by a variable pattern in a @case@ expression whose
---      scrutinee is the decreasing argument @xᵢ@.
+--   1. The decreasing argument itself is at depth @0@.
 --
---   2. @x@ is bound by a variable pattern in a @case@ expression whose
---      scrutinee is structurally smaller that @xᵢ@ itself.
+--   2. The variables @x₁, …, xₙ@ that are bound by an alternative
+--      @case e of { … ; C x₁ … xₙ -> e' ; … }@ of a @case@-expression whose
+--      scrutinee @e@ is at depth @d@ are at depth @d + 1@ within the right-
+--      hand side @e@ of the alternative.
+--
+--   3. The variables @x₁, …, xₙ@ that are bound by a @let@-binding
+--      @let { x₁ = e₁ ; … ; xₙ = eₙ } in e@ whose right-hand sides @e₁, …, eₙ@
+--      are at depths @d₁, …, dₙ@ are at the same depths within the @in@-
+--      expression @e@ as well as in the right-hand sides @e₁, …, eₙ@.
+--
+--   4. All other variables and non-variable expressions are at depth @⊥@.
+--
+--   An expression is structurally smaller than the decreasing argument if
+--   its depth is greater than the depth of the decreasing argument, i.e., @>0@.
+--   The definition above ensures that
+--
+--    * variables that are introduced by @case@-expression alternatives are
+--      structurally smaller than the scrutinee of the @case@-expression and
+--    * variables that are introduced by @let@-bindings are structually equal
+--      to their right-hand side.
 --
 --   == Bypassing the termination checker
 --
---   Cop's termination checker uses the same idea as described above but
+--   Coq's termination checker uses the same idea as described above but
 --   is much more sophisticated. If the user knows that their function
 --   declaration is decreasing on one of its arguments, they can annotate
 --   the decreasing argument using a custom pragma (see also
@@ -66,7 +85,6 @@ module FreeC.Backend.Coq.Analysis.DecreasingArguments
 import           Data.List             ( find )
 import           Data.Map.Strict       ( Map )
 import qualified Data.Map.Strict       as Map
-import           Data.Set              ( (\\), Set )
 import qualified Data.Set              as Set
 import           Data.Tuple.Extra      ( uncurry3 )
 
@@ -75,7 +93,6 @@ import qualified FreeC.IR.Syntax       as IR
 import           FreeC.Monad.Converter
 import           FreeC.Monad.Reporter
 import           FreeC.Pretty
-import           FreeC.Util.Predicate  ( (.||.) )
 
 -------------------------------------------------------------------------------
 -- Guessing Decreasing Arguments                                             --
@@ -141,35 +158,36 @@ checkDecArgs decls knownDecArgIndecies decArgIndecies = all
   checkDecArg (Just _) _ _ = True
   checkDecArg _ decArgIndex (IR.FuncDecl _ _ _ args _ rhs)
     = let decArg = IR.varPatQName (args !! decArgIndex)
-      in checkExpr decArg Set.empty rhs []
+      in checkExpr (Map.singleton decArg 0) rhs []
 
   -- | Tests whether there is a variable that is structurally smaller than the
   --   argument with the given name in the position of decreasing arguments of
   --   all applications of functions from the strongly connected component.
   --
-  --   The second argument is a set of variables that are known to be
-  --   structurally smaller than the decreasing argument of the function
-  --   whose right-hand side is checked.
+  --   The first argument maps variables that are known to be structurally
+  --   smaller or equal than the decreasing argument of the function whose
+  --   right-hand side is checked to their depth within the structure. The
+  --   decreasing argument itself and its aliases have a depth of @0@.
   --
   --   The last argument is a list of actual arguments passed to the given
   --   expression.
-  checkExpr :: IR.QName -> Set IR.QName -> IR.Expr -> [IR.Expr] -> Bool
-  checkExpr decArg smaller = checkExpr'
+  checkExpr :: Map IR.QName Int -> IR.Expr -> [IR.Expr] -> Bool
+  checkExpr depthMap = checkExpr'
    where
-    -- | Tests whether the given expression is the decreasing argument.
-    isDecArg :: IR.Expr -> Bool
-    isDecArg (IR.Var _ varName _) = varName == decArg
-    isDecArg _                    = False
+    -- | Gets the depth of an expression within the structure of the decreasing
+    --   argument.
+    --
+    --   Returns @Nothing@ if the given expression it is not a subterm of the
+    --   decreasing argument. The decreasing argument itself and its aliases
+    --   have a depth of @0@.
+    lookupDepth :: IR.Expr -> Maybe Int
+    lookupDepth (IR.Var _ varName _) = Map.lookup varName depthMap
+    lookupDepth _                    = Nothing
 
-    -- | Tests whether the given expression is a structurally smaller
-    --   variable than the decreasing argument.
+    -- | Tests whether the given expression is structurally smaller than the
+    --   decreasing argument.
     isSmaller :: IR.Expr -> Bool
-    isSmaller (IR.Var _ varName _) = varName `elem` smaller
-    isSmaller _                    = False
-
-    -- | Tests whether the given expression matches 'isDecArg' or 'isSmaller'.
-    isDecArgOrSmaller :: IR.Expr -> Bool
-    isDecArgOrSmaller = isDecArg .||. isSmaller
+    isSmaller = any (> 0) . lookupDepth
 
     -- If one of the recursive functions is applied, there must be a
     -- structurally smaller variable in the decreasing position.
@@ -183,24 +201,24 @@ checkDecArgs decls knownDecArgIndecies decArgIndecies = all
     -- arguments such that the case above can inspect the actual arguments.
     checkExpr' (IR.App _ e1 e2 _) args          = checkExpr' e1 (e2 : args)
       && checkExpr' e2 []
+    -- Recursively check branches of @if@ expressions.
     checkExpr' (IR.If _ e1 e2 e3 _) _
       = checkExpr' e1 [] && checkExpr' e2 [] && checkExpr' e3 []
-    -- @case@-expressions that match the decreasing argument or a variable
-    -- that is structurally smaller than the decreasing argument, introduce
-    -- new structurally smaller variables.
-    checkExpr' (IR.Case _ expr alts _) _
-      | isDecArgOrSmaller expr = all checkSmallerAlt alts
-      | otherwise = all checkAlt alts
-    -- The arguments of lambda expressions shadow existing (structurally
-    -- smaller) variables.
+    -- Alternatives of @case@-expressions introduce variables at a depth one
+    -- level deeper than the scrutinee.
+    checkExpr' (IR.Case _ scrutinee alts _) _   = all
+      (checkAlt (lookupDepth scrutinee)) alts
+    -- The depth of arguments of lambda expressions is unknown.
     checkExpr' (IR.Lambda _ args expr _) _
-      = let smaller' = withoutArgs args smaller
-        in checkExpr decArg smaller' expr []
-    -- The right hand side of a @let@-binding shadow existing (structurally
-    -- smaller) variables.
+      = let depthMap' = withoutArgs args depthMap
+        in checkExpr depthMap' expr []
+    -- The bindings of @let@-expressions  introduce variables at the same depth
+    -- as the expressions on their right-hand sides.
     checkExpr' (IR.Let _ binds expr _) _
-      = let smaller' = withoutArgs (map IR.bindVarPat binds) smaller
-        in checkExpr decArg smaller' expr [] && all (checkBind smaller') binds
+      = let varPats   = map IR.bindVarPat binds
+            varDepths = map (lookupDepth . IR.bindExpr) binds
+            depthMap' = withDepths (zip varPats varDepths) depthMap
+        in checkExpr depthMap' expr [] && all (checkBind depthMap') binds
     -- Recursively check visibly applied expressions.
     checkExpr' (IR.TypeAppExpr _ expr _ _) args = checkExpr' expr args
     -- Base expressions don't contain recursive calls.
@@ -212,36 +230,43 @@ checkDecArgs decls knownDecArgIndecies decArgIndecies = all
     -- | Applies 'checkExpr' on the right-hand side of an alternative of a
     --   @case@ expression.
     --
-    --   The variable patterns shadow existing (structurally smaller)
-    --   variables with the same name.
-    checkAlt :: IR.Alt -> Bool
-    checkAlt (IR.Alt _ _ varPats expr)
-      = let smaller' = withoutArgs varPats smaller
-        in checkExpr decArg smaller' expr []
+    --   The variable patterns shadow existing (structurally smaller or equal)
+    --   variables with the same name. The first argument is the depth of the
+    --   scrutinee (or @Nothing@ if it is not a subterm of the decreasing
+    --   argument). The variable patterns of the alternative are one level
+    --   deeper than the scrutinee.
+    checkAlt :: Maybe Int -> IR.Alt -> Bool
+    checkAlt srutineeDepth (IR.Alt _ _ varPats expr)
+      = let varDepths = repeat (succ <$> srutineeDepth)
+            depthMap' = withDepths (zip varPats varDepths) depthMap
+        in checkExpr depthMap' expr []
 
-    checkBind :: Set IR.QName -> IR.Bind -> Bool
-    checkBind smaller' (IR.Bind _ _ expr) = checkExpr decArg smaller' expr []
-
-    -- | Like 'checkAlt' but for alternatives of @case@-expressions on
-    --   the decreasing argument or a variable that is structurally smaller.
+    -- | Applies 'checkExpr' to the right-hand side of a binding of a
+    --   @let@ expression.
     --
-    --   All variable patterns are added to the set of structurally smaller
-    --   variables.
-    checkSmallerAlt :: IR.Alt -> Bool
-    checkSmallerAlt (IR.Alt _ _ varPats expr)
-      = let smaller' = withArgs varPats smaller
-        in checkExpr decArg smaller' expr []
+    --   The variables that are bound by the let expression should have been
+    --   shadowed already.
+    checkBind :: Map IR.QName Int -> IR.Bind -> Bool
+    checkBind depthMap' (IR.Bind _ _ expr) = checkExpr depthMap' expr []
 
-    -- | Adds the given variables to the set of structurally smaller
-    --   variables.
-    withArgs :: [IR.VarPat] -> Set IR.QName -> Set IR.QName
-    withArgs args set = set `Set.union` Set.fromList (map IR.varPatQName args)
+    -- | Sets the depth of the variable that is bound by the given pattern
+    --   or removes the entry from the map if the new depth is @Nothing@.
+    withDepth :: IR.VarPat -> Maybe Int -> Map IR.QName Int -> Map IR.QName Int
+    withDepth varPat maybeDepth = Map.alter (const maybeDepth)
+      (IR.varPatQName varPat)
 
-    -- | Removes the given variables to the set of structurally smaller
+    -- | Sets the depths of the variables that are bound by the given patterns
+    --   or removes the corresponding entries from the map if the new depth
+    --   is @Nothing@.
+    withDepths
+      :: [(IR.VarPat, Maybe Int)] -> Map IR.QName Int -> Map IR.QName Int
+    withDepths = flip (foldr (uncurry withDepth))
+
+    -- | Removes the given variables from the set of structurally smaller
     --   variables (because they are shadowed by an argument from a lambda
     --   abstraction or @case@-alternative).
-    withoutArgs :: [IR.VarPat] -> Set IR.QName -> Set IR.QName
-    withoutArgs args set = set \\ Set.fromList (map IR.varPatQName args)
+    withoutArgs :: [IR.VarPat] -> Map IR.QName Int -> Map IR.QName Int
+    withoutArgs = flip Map.withoutKeys . Set.fromList . map IR.varPatQName
 
 -------------------------------------------------------------------------------
 -- Identifying Decreasing Arguments                                          --

--- a/src/test/FreeC/Backend/Coq/Analysis/DecreasingArgumentsTests.hs
+++ b/src/test/FreeC/Backend/Coq/Analysis/DecreasingArgumentsTests.hs
@@ -71,3 +71,17 @@ testDecreasingArguments
         ++ "           }"
         ++ "  }"
       identifyDecArgs [funcDecl] `shouldReturn` [0]
+    it "allows aliases of the decreasing argument" $ do
+      funcDecl <- expectParseTestFuncDecl
+        $ "tails xs = let { xs0 = xs } in Cons xs0 (case xs0 of {"
+        ++ "      Nil        -> Nil;"
+        ++ "      Cons x xs' -> tails xs'"
+        ++ "    })"
+      identifyDecArgs [funcDecl] `shouldReturn` [0]
+    it "allows aliases of structurally smaller variables" $ do
+      funcDecl <- expectParseTestFuncDecl
+        $ "pow2 n = case n of {"
+        ++ "    Zero -> Succ Zero;"
+        ++ "    Succ n' -> let { n'0 = n' } in add (pow2 n'0) (pow2 n'0)"
+        ++ "  }"
+      identifyDecArgs [funcDecl] `shouldReturn` [0]


### PR DESCRIPTION
<!--
  Have you read our Code of Conduct?
  By filing an issue or pull request, you are expected to comply with it, including treating everyone with respect:
  https://github.com/FreeProving/guidelines/blob/main/CODE_OF_CONDUCT.md
-->

### Issue

<!--
  Link to the issue that this pull request addresses.
  If there is not yet a corresponding issue, please open a new issue and then link to that issue in your pull request.
  Give any additional information that is not covered by the linked issue but might be important for the reviewer.
-->
Closes #192.

### Description of the Change

<!--
  Give a short summary of the changes you made to handle the issue.
  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
-->
The decreasing argument analysis now remembers for every variable how deep it is nested in the decreasing argument. A depth of `0` is assigned to the decreasing argument itself. Pattern matching introduces variables at one layer deeper than the scrutinee. `let`-bindings introduce variables at the same depth as the right-hand side. A variable is structurally smaller than the decreasing argument if its depth is greater than zero.

### Verification Process

<!--
  What process did you follow to verify that your change has the desired effects and has not introduced any regressions?
  Describe the actions you performed (including input you checked, tests you created, commands you ran, etc.), and describe the results you observed.
-->
Some test cases have been added for `identifyDecArgs`.

### Additional Notes

<!-- Is there anything else worth mentioning (e.g. changes by your PR that other contributors have to be aware of, ideas for further enhancements, etc.)? -->
Unless `share` is replaced by `pure` during the translation of helper functions to Coq for the decreasing argument and structurally smaller variables as described in #192, our termination checker accepts more programs that Coq's termination checker. Thus, additional translation logic has to be added to satisfy Coq's termination checker once #179 is merged.
