### PR TITLE
Fix bug #209

### DIFF
--- a/src/lib/FreeC/Backend/Coq/Analysis/DecreasingArguments.hs
+++ b/src/lib/FreeC/Backend/Coq/Analysis/DecreasingArguments.hs
@@ -264,7 +264,7 @@ depthMapAt p expr decArg = foldr (uncurry extendDepthMap) (initDepthMap decArg)
   --   as the index (starting at @1@) of the position within its parent
   --   position.
   selectParent :: Pos -> Maybe (Int, IR.Expr)
-  selectParent = fmap (fmap (selectSubterm' expr)) . unConsPos
+  selectParent = fmap (fmap (selectSubterm' expr)) . parentPos'
 
 -- | Applies the given function to the children of the given expression
 --   and the extended 'DepthMap' for that child.

--- a/src/lib/FreeC/IR/Subterm.hs
+++ b/src/lib/FreeC/IR/Subterm.hs
@@ -11,8 +11,8 @@ module FreeC.IR.Subterm
   , Pos(..)
   , rootPos
   , consPos
-  , unConsPos
   , parentPos
+  , parentPos'
   , ancestorPos
   , allPos
   , above
@@ -204,12 +204,13 @@ rootPos = Pos []
 consPos :: Int -> Pos -> Pos
 consPos p (Pos ps) = Pos (p : ps)
 
--- | Inverse function of 'consPos'.
+-- |  Gets the parent position or @Nothing@ if the given position is the
+--    root position.
 --
---   Returns @Nothing@ if the given position is the 'rootPos'.
-unConsPos :: Pos -> Maybe (Int, Pos)
-unConsPos (Pos [])       = Nothing
-unConsPos (Pos (p : ps)) = Just (p, Pos ps)
+--   Returns the index of the child term and the position of the parent term.
+parentPos' :: Pos -> Maybe (Int, Pos)
+parentPos' (Pos []) = Nothing
+parentPos' (Pos ps) = Just (last ps, Pos (init ps))
 
 -- | Gets the parent position or @Nothing@ if the given position is the
 --   root position.


### PR DESCRIPTION
The function `intersperse` could not be translated due to a bug in `Subterm`.
