### PR TITLE
Fix #223

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -2,7 +2,7 @@
 -- is downloaded directly from the FreeProving GitHub organization instead.
 source-repository-package
   type: git
-  location: git://github.com/FreeProving/language-coq.git
+  location: git@github.com:FreeProving/language-coq.git
   tag: v0.4.0.0
 
 -- The `haskell-src-transformations` package is still in an early development
@@ -10,7 +10,7 @@ source-repository-package
 -- directly from the FreeProving GitHub organization instead.
 source-repository-package
   type: git
-  location: git://github.com/FreeProving/haskell-src-transformations.git
+  location: git@github.com:FreeProving/haskell-src-transformations.git
   tag: v0.2.0.0
 
 -- Cabal configuration file for this package.


### PR DESCRIPTION
### Issue

#223 

### Description of the Change

Updated the git references of the `cabal.project` file so they use a supported git protocol.

### Verification Process

Running `cabal new-install freec` does not produce the error mentioned in #223.
