### PR TITLE
Fix #225

### DIFF
--- a/free-compiler.cabal
+++ b/free-compiler.cabal
@@ -56,7 +56,7 @@ flag PolysemyPluginEnabled
 common deps
   build-depends:     base                        ==4.12.*
                      -- ASTs:
-                   , Agda                        ==2.6.*
+                   , Agda                        ==2.6.1
                    , haskell-src-exts            ==1.23.*
                    , language-coq                ==0.4.*
                      -- Configuration:


### PR DESCRIPTION
### Issue

#225 

### Description of the Change

Fixed Agda version to 2.6.1 as 2.6.* is too lax a rule (i.e., 2.6.2.2 leads to errors).

### Verification Process

Running `cabal new-install freec` does not produce the error mentioned in #225.
